### PR TITLE
Fix bug of saveAsTextFile()

### DIFF
--- a/pysparkling/fileio/fs/local.py
+++ b/pysparkling/fileio/fs/local.py
@@ -65,7 +65,7 @@ class Local(FileSystem):
 
         # making sure directory exists
         dirname = os.path.dirname(path_local)
-        if not os.path.exists(dirname):
+        if dirname and not os.path.exists(dirname):
             log.debug('creating local directory {0}'.format(dirname))
             os.makedirs(dirname)
 


### PR DESCRIPTION
When saveAsTextFile() is used with a local file, and the rdd has 1 partition, `makedirs()` is called on a empty string, causing an un-catched exception.