### PR TITLE
Add accumulators, update broadcasts

### DIFF
--- a/pysparkling/__init__.py
+++ b/pysparkling/__init__.py
@@ -9,6 +9,7 @@ from .exceptions import (FileAlreadyExistsException,
 from .rdd import RDD
 from .context import Context
 from .broadcast import Broadcast
+from .accumulators import  Accumulator, AccumulatorParam
 from .stat_counter import StatCounter
 from .cache_manager import CacheManager
 

--- a/pysparkling/accumulators.py
+++ b/pysparkling/accumulators.py
@@ -1,0 +1,155 @@
+
+"""
+>>> from pysparkling import Context
+>>> sc = Context()
+>>> a = sc.accumulator(1)
+>>> a.value
+1
+>>> a.value = 2
+>>> a.value
+2
+>>> a += 5
+>>> a.value
+7
+
+>>> sc.accumulator(1.0).value
+1.0
+
+>>> sc.accumulator(1j).value
+1j
+
+>>> rdd = sc.parallelize([1,2,3])
+>>> def f(x):
+...     global a
+...     a += x
+>>> rdd.foreach(f)
+>>> a.value
+13
+
+>>> b = sc.accumulator(0)
+>>> def g(x):
+...     b.add(x)
+>>> rdd.foreach(g)
+>>> b.value
+6
+
+>>> from pysparkling import AccumulatorParam
+>>> class VectorAccumulatorParam(AccumulatorParam):
+...     def zero(self, value):
+...         return [0.0] * len(value)
+...     def addInPlace(self, val1, val2):
+...         for i in range(len(val1)):
+...              val1[i] += val2[i]
+...         return val1
+>>> va = sc.accumulator([1.0, 2.0, 3.0], VectorAccumulatorParam())
+>>> va.value
+[1.0, 2.0, 3.0]
+>>> def g(x):
+...     global va
+...     va += [x] * 3
+>>> rdd.foreach(g)
+>>> va.value
+[7.0, 8.0, 9.0]
+
+>>> sc.accumulator([1.0, 2.0, 3.0]) # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+...
+TypeError: No default accumulator param for type <type 'list'>
+"""
+
+
+__all__ = ['Accumulator', 'AccumulatorParam']
+
+
+
+class Accumulator(object):
+    """
+    A shared variable that can be accumulated, i.e., has a commutative and associative "add"
+    operation. Tasks can add values to an Accumulator with the ``+=`` operator
+
+    The API supports accumulators for primitive data types like ``int`` and
+    ``float``, users can also define accumulators for custom types by providing a custom
+    ``AccumulatorParam`` object. Refer to the doctest of this module for an example.
+    """
+
+    def __init__(self, value, accum_param):
+        """Create a new Accumulator with a given initial value and AccumulatorParam object"""
+        self.accum_param = accum_param
+        self._value = value
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
+
+    def add(self, term):
+        """Adds a term to this accumulator's value"""
+        self._value = self.accum_param.addInPlace(self._value, term)
+
+    def __iadd__(self, term):
+        """The += operator; adds a term to this accumulator's value"""
+        self.add(term)
+        return self
+
+    def __str__(self):
+        return str(self._value)
+
+    def __repr__(self):
+        return "Accumulator<value={0}>".format(self._value)
+
+
+class AccumulatorParam(object):
+    """
+    Helper object that defines how to accumulate values of a given type.
+    """
+    def zero(self, value):
+        """
+        Provide a "zero value" for the type, compatible in dimensions with the
+        provided ``value`` (e.g., a zero vector)
+        """
+        raise NotImplementedError
+
+    def addInPlace(self, value1, value2):
+        """
+        Add two values of the accumulator's data type, returning a new value;
+        for efficiency, can also update ``value1`` in place and return it.
+        """
+        raise NotImplementedError
+
+
+class AddingAccumulatorParam(AccumulatorParam):
+    """
+    An AccumulatorParam that uses the + operators to add values. Designed for simple types
+    such as integers, floats, and lists. Requires the zero value for the underlying type
+    as a parameter.
+    """
+    def __init__(self, zero_value):
+        self.zero_value = zero_value
+
+    def zero(self, value):
+        return self.zero_value
+
+    def addInPlace(self, value1, value2):
+        value1 += value2
+        return value1
+
+
+# Singleton accumulator params for some standard types
+INT_ACCUMULATOR_PARAM = AddingAccumulatorParam(0)
+FLOAT_ACCUMULATOR_PARAM = AddingAccumulatorParam(0.0)
+COMPLEX_ACCUMULATOR_PARAM = AddingAccumulatorParam(0.0j)
+
+
+if __name__ == "__main__":
+    """
+    Execute doctests with
+
+    $ python -m pysparkling.accumulators -v
+    """
+    import doctest
+    failure_count, _ = doctest.testmod()
+    if failure_count:
+        exit(-1)

--- a/pysparkling/accumulators.py
+++ b/pysparkling/accumulators.py
@@ -1,3 +1,21 @@
+# A large part of this module is extracted from its PySpark counterpart at
+# https://spark.apache.org/docs/1.5.0/api/python/_modules/pyspark/accumulators.html
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 """
 >>> from pysparkling import Context

--- a/pysparkling/broadcast.py
+++ b/pysparkling/broadcast.py
@@ -1,4 +1,42 @@
 
+__all__ = ['Broadcast']
+
+
 class Broadcast(object):
-    def __init__(self, value):
-        self.value = value
+    """
+    A broadcast variable created with ``b = sc.broadcast(0)``.
+    Access its value through ``b.value``.
+
+    Examples:
+
+    >>> from pysparkling import Context
+    >>> sc = Context()
+    >>> b = sc.broadcast([1, 2, 3, 4, 5])
+    >>> b.value
+    [1, 2, 3, 4, 5]
+    >>> sc.parallelize([0, 0]).flatMap(lambda x: b.value).collect()
+    [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+    >>> b.value += [1]
+    Traceback (most recent call last):
+    ...
+    AttributeError: can't set attribute
+    """
+    def __init__(self, sc=None, value=None):
+        self._value = value
+
+    @property
+    def value(self):
+        """Returs the broadcasted value."""
+        return self._value
+
+
+if __name__ == "__main__":
+    """
+    Execute doctests with
+
+    $ python -m pysparkling.broadcast -v
+    """
+    import doctest
+    failure_count, _ = doctest.testmod()
+    if failure_count:
+        exit(-1)

--- a/pysparkling/broadcast.py
+++ b/pysparkling/broadcast.py
@@ -1,3 +1,21 @@
+# A large part of this module is extracted from its PySpark counterpart at
+# https://spark.apache.org/docs/1.5.0/api/python/_modules/pyspark/broadcast.html
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 __all__ = ['Broadcast']
 

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -123,6 +123,8 @@ class Context(object):
         and floating-point numbers if you do not provide one. For other types,
         a custom AccumulatorParam can be used.
         """
+        if not isinstance(self._pool, DummyPool):
+            raise NotImplementedError('Accumulators are not yet compatible with multiprocessing')
         if accum_param is None:
             if isinstance(value, int):
                 accum_param = accumulators.INT_ACCUMULATOR_PARAM

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -11,6 +11,7 @@ import time
 
 from . import __version__ as PYSPARKLING_VERSION
 from .broadcast import Broadcast
+from . import accumulators
 from .cache_manager import CacheManager
 from .fileio import File, TextFile
 from .partition import Partition
@@ -113,6 +114,25 @@ class Context(object):
 
     def broadcast(self, x):
         return Broadcast(self, x)
+
+    def accumulator(self, value, accum_param=None):
+        """
+        Create an ``Accumulator`` with the given initial value, using a given
+        ``AccumulatorParam`` helper object to define how to add values of the
+        data type if provided. Default AccumulatorParams are used for integers
+        and floating-point numbers if you do not provide one. For other types,
+        a custom AccumulatorParam can be used.
+        """
+        if accum_param is None:
+            if isinstance(value, int):
+                accum_param = accumulators.INT_ACCUMULATOR_PARAM
+            elif isinstance(value, float):
+                accum_param = accumulators.FLOAT_ACCUMULATOR_PARAM
+            elif isinstance(value, complex):
+                accum_param = accumulators.COMPLEX_ACCUMULATOR_PARAM
+            else:
+                raise TypeError("No default accumulator param for type {0}".format(type(value)))
+        return accumulators.Accumulator(value, accum_param)
 
     def newRddId(self):
         Context.__last_rdd_id += 1

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -112,7 +112,7 @@ class Context(object):
         self.version = PYSPARKLING_VERSION
 
     def broadcast(self, x):
-        return Broadcast(x)
+        return Broadcast(self, x)
 
     def newRddId(self):
         Context.__last_rdd_id += 1


### PR DESCRIPTION
`Broadcast` changes were made to make sure that `Broadcast` initialization has the same arguments as its `pyspark` counterpart (context as first argument).

`Accumulator` and `AccumulatorParam` implementation is partly taken from their `pyspark` counterparts. Note that this implementation does not support parallelization, but such addition should be fairly doable on top of current implementation (again, by looking at the `pyspark` counterpart).

Tests are passing, I added tests by re-using `pyspark` doctests.

Fixes #25 
