### PR TITLE
make codebase compatible with python 2.6

### DIFF
--- a/pysparkling/cache_manager.py
+++ b/pysparkling/cache_manager.py
@@ -98,9 +98,9 @@ class CacheManager(object):
         :returns:
             All cache entries that are not in the given list.
         """
-        return {i: c
-                for i, c in self.cache_obj.items()
-                if i not in idents}
+        return dict((i, c)
+                    for i, c in self.cache_obj.items()
+                    if i not in idents)
 
     def join(self, cache_objects):
         """join
@@ -131,9 +131,9 @@ class CacheManager(object):
         cm = CacheManager(self.max_mem,
                           self.serializer, self.deserializer,
                           self.checksum)
-        cm.cache_obj = {i: c
-                        for i, c in self.cache_obj.items()
-                        if filter_id(i)}
+        cm.cache_obj = dict((i, c)
+                            for i, c in self.cache_obj.items()
+                            if filter_id(i))
         return cm
 
     def delete(self, ident):

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -56,9 +56,9 @@ class RDD(object):
         self._rdd_id = ctx.newRddId()
 
     def __getstate__(self):
-        r = {k: v
-             for k, v in self.__dict__.items()
-             if k not in ('_p', 'context')}
+        r = dict((k, v)
+                 for k, v in self.__dict__.items()
+                 if k not in ('_p', 'context'))
         return r
 
     def compute(self, split, task_context):
@@ -1295,7 +1295,7 @@ class RDD(object):
             fileio.TextFile(
                 path
             ).dump(io.StringIO(''.join([
-                '{}\n'.format(xx) for xx in self.toLocalIterator()
+                '{0}\n'.format(xx) for xx in self.toLocalIterator()
             ])))
             return self
 
@@ -1305,7 +1305,7 @@ class RDD(object):
                 os.path.join(path, 'part-{0:05d}{1}'.format(tc.partitionId(),
                                                             codec_suffix))
             ).dump(io.StringIO(''.join([
-                '{}\n'.format(xx) for xx in x
+                '{0}\n'.format(xx) for xx in x
             ]))),
             resultHandler=list,
         )


### PR DESCRIPTION
dict comprehensions have been removed in order to enable using
pysparkling with python 2.6. Some 2.6 formatting code changed.
