### PR TITLE
Feat/file get content alt

### DIFF
--- a/pysparkling/fileio/file.py
+++ b/pysparkling/fileio/file.py
@@ -41,6 +41,24 @@ class File(object):
         log.debug('Filenames: {0}'.format(files))
         return files
 
+    @classmethod
+    def get_content(cls, all_expr):
+        """Return all files matching or in folder matching one of the given expression
+
+        :param all_expr:
+            A list of expressions.
+            The expressions can contain the wildcard characters ``*`` and ``?``.
+
+        :returns: A list of file names.
+        :rtype: list
+        """
+        files = []
+        for expr in all_expr:
+            expr = expr.strip()
+            files += fs.get_fs(expr).resolve_content(expr)
+        log.debug('Filenames: {0}'.format(files))
+        return files
+
     def exists(self):
         """Checks both for a file or directory at this location.
 

--- a/pysparkling/fileio/fs/file_system.py
+++ b/pysparkling/fileio/fs/file_system.py
@@ -19,6 +19,14 @@ class FileSystem(object):
         """
         log.error('Cannot resolve: {0}'.format(expr))
 
+    @staticmethod
+    def resolve_content(expr):
+        """Return all the files matching expr or in a folder matching expr
+
+        :rtype: list
+        """
+        log.error('Cannot resolve: {0}'.format(expr))
+
     def exists(self):
         """Check whether the given file_name exists.
 

--- a/pysparkling/fileio/fs/hdfs.py
+++ b/pysparkling/fileio/fs/hdfs.py
@@ -123,7 +123,9 @@ class Hdfs(FileSystem):
                     file_path = format_file_uri(scheme, domain, file_local_path)
                     file_paths.append(file_path)
             elif file_status["type"] == "DIRECTORY":
-                file_paths += cls._get_folder_files_by_expr(c, scheme, domain, file_local_path + "/", expr)
+                file_paths += cls._get_folder_files_by_expr(
+                    c, scheme, domain, file_local_path + "/", expr
+                )
         return file_paths
 
     @classmethod

--- a/pysparkling/fileio/fs/hdfs.py
+++ b/pysparkling/fileio/fs/hdfs.py
@@ -128,7 +128,7 @@ class Hdfs(FileSystem):
 
     @classmethod
     def resolve_content(cls, expr):
-        c, _ = Hdfs.client_and_path(expr)
+        c, _ = cls.client_and_path(expr)
 
         scheme, domain, folder_path, pattern = parse_file_uri(expr)
 

--- a/pysparkling/fileio/fs/local.py
+++ b/pysparkling/fileio/fs/local.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import glob
 from fnmatch import fnmatch
 import io
 import logging
@@ -34,6 +35,24 @@ class Local(FileSystem):
                 if fnmatch(path, expr) or fnmatch(path, expr + '/part*'):
                     files.append(path)
         return files
+
+    @staticmethod
+    def resolve_content(expr):
+        if expr.startswith('file://'):
+            expr = expr[7:]
+        matches = glob.glob(expr)
+        file_paths = []
+        for match in matches:
+            if os.path.isfile(match):
+                file_paths.append(match)
+            else:
+                file_paths += [
+                    os.path.join(root, f)
+                    for root, _, files in os.walk(match)
+                    for f in files
+                    if not f.startswith(("_", "."))
+                ]
+        return file_paths
 
     @property
     def file_path(self):

--- a/pysparkling/utils.py
+++ b/pysparkling/utils.py
@@ -1,4 +1,8 @@
+import re
 from operator import itemgetter
+
+
+WILDCARD_START_PATTERN = re.compile(r'(?P<previous_character>^|[^\\])(?P<wildcard_start>[*?[])')
 
 
 class Tokenizer(object):
@@ -34,7 +38,13 @@ def parse_file_uri(expr):
     t = Tokenizer(expr)
     scheme = t.next('://')
     domain = t.next('/')
-    last_slash_position = t.expression.rfind('/')
+    wildcard_match = next(WILDCARD_START_PATTERN.finditer(t.expression), None)
+    if wildcard_match is not None:
+        first_pattern_position = wildcard_match.start("wildcard_start")
+    else:
+        first_pattern_position = len(t.expression)
+
+    last_slash_position = t.expression.rfind('/', 0, first_pattern_position)
     folder_path = '/' + t.expression[:last_slash_position+1]
     file_pattern = t.expression[last_slash_position+1:]
 


### PR DESCRIPTION
Same as #95 but with a rewritten history:

It adds to `FileSystem` abstract class and most of its implementation a `resolve_content` method that resolves paths like Spark 2.

For instance `spark.read.csv("/some/path/")` will resolve to all the file hierarchy contained in `/some/path`, not only `/some/path/part-xxx`