### PR TITLE
Feat/rdd functions alt

### DIFF
--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -418,6 +418,16 @@ class RDD(object):
         """
         return self.count()
 
+    def countApproxDistinct(self):
+        """return the number of distinct values
+
+        :rtype: int
+
+        .. note::
+            The operation is currently implemented as a local and exact operation.
+        """
+        return len(set(self.toLocalIterator()))
+
     def countByKey(self):
         """returns a `dict` containing the count for every key
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -23,12 +23,12 @@ try:
 except ImportError:
     numpy = None
 
-from pysparkling import fileio
-from pysparkling.utils import portable_hash
-from pysparkling.exceptions import FileAlreadyExistsException, ContextIsLockedException
-from pysparkling.samplers import (BernoulliSampler, PoissonSampler,
-                                  BernoulliSamplerPerKey, PoissonSamplerPerKey)
-from pysparkling.stat_counter import StatCounter
+from . import fileio
+from .utils import portable_hash
+from .exceptions import FileAlreadyExistsException, ContextIsLockedException
+from .samplers import (BernoulliSampler, PoissonSampler,
+                       BernoulliSamplerPerKey, PoissonSamplerPerKey)
+from .stat_counter import StatCounter
 
 maxint = sys.maxint if hasattr(sys, 'maxint') else sys.maxsize  # pylint: disable=no-member
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -162,6 +162,7 @@ class RDD(object):
         >>> (r['a'], r['b'])
         (4, 2)
         """
+
         def seqFuncByKey(tc, i):
             r = defaultdict(lambda: copy.deepcopy(zeroValue))
             for k, v in i:
@@ -221,6 +222,18 @@ class RDD(object):
         4
         """
         return self.persist()
+
+    def glom(self):
+        """coalesce into a list elements of a partition
+
+        :rtype: RDD
+
+        >>> from pysparkling import Context
+        >>> rdd = Context().parallelize([1, 2, 3, 4], 2)
+        >>> sorted(rdd.glom().collect())
+        [[1, 2], [3, 4]]
+        """
+        return self.mapPartitions(lambda items: [list(items)])
 
     def cartesian(self, other):
         """cartesian product of this RDD with ``other``

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -314,19 +314,23 @@ class RDD(object):
         number_of_big_groups = current_num_partitions % new_num_partitions
         number_of_small_groups = new_num_partitions - number_of_big_groups
 
-        def slice_partition_content(partitions, start, end):
-            return itertools.chain(*(p.x() for p in partitions[start:end]))
+        partition_mapping = ([p for p in range(number_of_big_groups)
+                              for _ in range(big_group_size)] +
+                             [p for p in range(number_of_big_groups,
+                                               number_of_big_groups + number_of_small_groups)
+                              for _ in range(small_group_size)])
+        new_partitions = {i: [] for i in range(new_num_partitions)}
 
         def partitioned():
-            start = 0
-            for _ in range(number_of_big_groups):
-                end = start + big_group_size
-                yield slice_partition_content(self._p, start, end)
-                start = end
-            for _ in range(number_of_small_groups):
-                end = start + small_group_size
-                yield slice_partition_content(self._p, start, end)
-                start = end
+            def move_partition_content(partition_index, partition):
+                new_partitions[partition_mapping[partition_index]] += partition
+                return []
+
+            # trigger an evaluation with count
+            self.mapPartitionsWithIndex(move_partition_content).count()
+
+            for p in list(new_partitions.values()):
+                yield p
 
         # noinspection PyProtectedMember
         return self.context._parallelize_partitions(partitioned())

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -1716,6 +1716,24 @@ class RDD(object):
             preservesPartitioning=True,
         )
 
+    def subtractByKey(self, other, numPartitions=None):
+        """
+        Return each (key, value) pair in C{self} that has no pair with matching
+        key in C{other}.
+        >>> from pysparkling import Context
+        >>> sc = Context()
+        >>> x = sc.parallelize([("a", 1), ("b", 4), ("b", 5), ("a", 2)])
+        >>> y = sc.parallelize([("a", 3), ("c", None)])
+        >>> sorted(x.subtractByKey(y).collect())
+        [('b', 4), ('b', 5)]
+        """
+
+        def filter_func(pair):
+            _, (val1, val2) = pair
+            return val1 and not val2
+
+        return self.cogroup(other, numPartitions).filter(filter_func).flatMapValues(lambda x: x[0])
+
     def sum(self):
         """sum of all the elements
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -1337,11 +1337,9 @@ class RDD(object):
         def partition_sort(data):
             return sorted(data, key=keyfunc, reverse=not ascending)
 
-        return (
-            self
-            .partitionBy(numPartitions, partitionFunc)
-            .mapPartitions(partition_sort)
-        )
+        return (self
+                .partitionBy(numPartitions, partitionFunc)
+                .mapPartitions(partition_sort))
 
     def rightOuterJoin(self, other, numPartitions=None):
         """right outer join
@@ -1467,6 +1465,19 @@ class RDD(object):
         1.0
         """
         return self.stats().sampleVariance()
+
+    def isEmpty(self):
+        """
+        Returns whether or not RDD contains elements.
+
+        :rtype: bool
+        >>> from pysparkling import Context
+        >>> Context().parallelize([]).isEmpty()
+        True
+        >>> Context().parallelize([1]).isEmpty()
+        False
+        """
+        return not self.partitions() or len(self.take(1)) == 0
 
     def saveAsPickleFile(self, path, batchSize=10):
         """save as pickle file

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -1749,6 +1749,11 @@ class RDD(object):
         return self.context.runJob(self, lambda tc, x: sum(x),
                                    resultHandler=sum)
 
+    def sumApprox(self):
+        """same as :func:`~pysparkling.RDD.sum()`
+        """
+        return self.sum()
+
     def take(self, n):
         """Take n elements and return them in a list.
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -23,17 +23,20 @@ try:
 except ImportError:
     numpy = None
 
-from . import fileio
-from .exceptions import FileAlreadyExistsException, ContextIsLockedException
-from .samplers import (BernoulliSampler, PoissonSampler,
-                       BernoulliSamplerPerKey, PoissonSamplerPerKey)
-from .stat_counter import StatCounter
+from pysparkling import fileio
+from pysparkling.utils import portable_hash
+from pysparkling.exceptions import FileAlreadyExistsException, ContextIsLockedException
+from pysparkling.samplers import (BernoulliSampler, PoissonSampler,
+                                  BernoulliSamplerPerKey, PoissonSamplerPerKey)
+from pysparkling.stat_counter import StatCounter
+
+maxint = sys.maxint if hasattr(sys, 'maxint') else sys.maxsize  # pylint: disable=no-member
 
 log = logging.getLogger(__name__)
 
 
 def _hash(v):
-    return hash(v) & 0xffffffff
+    return portable_hash(v) & 0xffffffff
 
 
 class RDD(object):
@@ -2102,7 +2105,7 @@ class PartitionwiseSampledRDD(RDD):
         RDD.__init__(self, prev.partitions(), prev.context)
 
         if seed is None:
-            seed = random.randint(0, 2**31)
+            seed = random.randint(0, 2 ** 31)
 
         self.prev = prev
         self.sampler = sampler

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -1830,24 +1830,24 @@ class RDD(object):
         if num == 0:
             return []
 
-        initialCount = self.count()
-        if initialCount == 0:
+        initial_sample = self.take(num)
+        initial_count = len(initial_sample)
+        if initial_count == 0:
             return []
 
         rand = random.Random(seed)
 
-        if (not withReplacement) and num >= initialCount:
+        if (not withReplacement) and num >= initial_count:
             # shuffle current RDD and return
-            samples = self.collect()
-            rand.shuffle(samples)
-            return samples
+            rand.shuffle(initial_sample)
+            return initial_sample
 
         maxSampleSize = sys.maxsize - int(numStDev * math.sqrt(sys.maxsize))
         if num > maxSampleSize:
             raise ValueError(
                 "Sample size cannot be greater than %d." % maxSampleSize)
 
-        fraction = RDD._computeFractionForSampleSize(num, initialCount, withReplacement)
+        fraction = RDD._computeFractionForSampleSize(num, initial_count, withReplacement)
         samples = self.sample(withReplacement, fraction, seed).collect()
 
         # If the first sample didn't turn out large enough, keep trying to take samples;

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -1912,6 +1912,19 @@ class RDD(object):
         gamma = -math.log(delta) / total
         return min(1, fraction + gamma + math.sqrt(gamma * gamma + 2 * gamma * fraction))
 
+    def takeOrdered(self, n, key=lambda x: x):
+        """
+        Return the first n elements of the RDD based on ascending order.
+
+        A custom key function can be supplied to customize the sort order
+        >>> from pysparkling import Context
+        >>> Context().parallelize([10, 1, 2, 9, 3, 4, 5, 6, 7]).takeOrdered(6)
+        [1, 2, 3, 4, 5, 6]
+        >>> Context().parallelize([10, 1, 2, 9, 3, 4, 5, 6, 7], 2).takeOrdered(6, key=lambda x: -x)
+        [10, 9, 7, 6, 5, 4]
+        """
+        return self.sortBy(key).take(n)
+
     def toLocalIterator(self):
         """Returns an iterator over the dataset.
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -1249,11 +1249,45 @@ class RDD(object):
         >>> rdd.reduceByKey(lambda a, b: a+b).collect()
         [(0, 1), (1, 4)]
         """
-        return (
-            self
-            .groupByKey(numPartitions)
-            .mapValues(lambda x: functools.reduce(f, x))
-        )
+        return (self
+                .groupByKey(numPartitions)
+                .mapValues(lambda x: functools.reduce(f, x)))
+
+    def reduceByKeyLocally(self, f):
+        """reduce by key and return a dictionnary
+
+        :param f: A commutative and associative binary operator.
+        :param int numPartitions: Number of partitions in the resulting RDD.
+        :rtype: dict
+
+        >>> from pysparkling import Context
+        >>> from operator import add
+        >>> rdd = Context().parallelize([("a", 1), ("b", 1), ("a", 1)])
+        >>> sorted(rdd.reduceByKeyLocally(lambda a, b: a+b).items())
+        [('a', 2), ('b', 1)]
+        """
+        return dict(self.reduceByKey(f).collect())
+
+    def treeReduce(self, f, depth=2):
+        """same internal behaviour as :func:`~pysparkling.RDD.reduce()`
+
+        :param depth: Not used.
+
+        >>> from pysparkling import Context
+        >>> from operator import add
+        >>> rdd = Context().parallelize([-5, -4, -3, -2, -1, 1, 2, 3, 4], 10)
+        >>> rdd.treeReduce(add)
+        -5
+        >>> rdd.treeReduce(add, 1)
+        -5
+        >>> rdd.treeReduce(add, 2)
+        -5
+        >>> rdd.treeReduce(add, 5)
+        -5
+        >>> rdd.treeReduce(add, 10)
+        -5
+        """
+        return self.reduce(f)
 
     def repartition(self, numPartitions):
         """repartition

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -122,6 +122,13 @@ class RDD(object):
             ),
         )
 
+    def treeAggregate(self, zeroValue, seqOp, combOp, depth=2):
+        """same internal behaviour as :func:`~pysparkling.RDD.aggregate()`
+
+        :param depth: Not used.
+        """
+        return self.aggregate(zeroValue, seqOp, combOp)
+
     def aggregateByKey(self, zeroValue, seqFunc, combFunc, numPartitions=None):
         """aggregate by key
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -1048,6 +1048,7 @@ class RDD(object):
     def mean(self):
         """returns the mean of this dataset
 
+        :rtype: float
 
         Example:
 
@@ -1056,6 +1057,13 @@ class RDD(object):
         5.0
         """
         return self.stats().mean()
+
+    def meanApprox(self):
+        """same as :func:`~pysparkling.RDD.mean()`
+
+        :rtype: float
+        """
+        return self.mean()
 
     def min(self):
         """returns the minimum element"""


### PR DESCRIPTION
Same as #96 but with a rewritten history, it is on top of #100:

This PR:

Implements:
- RDD.countApproxDistinct
- RDD.glom
- RDD.isEmpty
- RDD.meanApprox
- RDD.subtractByKey
- RDD.sumApprox
- RDD.takeOrdered
- RDD.treeAggregate
- RDD.unpersist
- RDD.reduceByKeyLocally and RDD.treeReduce
- RDD semi join and anti join as private methods

Optimizes RDD.takeSample
Uses a portable hash function instead of Python's internal one to enhance reproducibility
Enhance coalesce resulting data distribution in some cases