### PR TITLE
Set pylint requested version to >=2.3 and <2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             'backports.tempfile==1.0rc1',
             'cloudpickle>=0.1.0',
             'futures>=3.0.1',
-            'pylint',
+            'pylint>=2.3,<2.6',
             'memory-profiler>=0.47',
             'pytest',
             'tornado>=4.3',


### PR DESCRIPTION
This PR sets Pylint requested version to be greater or equal than 2.3.0 but less than 2.6.0.

2.3.1 is the latest version supported by Python 2.3 and 2.5 is the latest version. pip will choose 2.5.x by default when available

This way we consider Pylint latest bugfixes (e.g. 2.5.1, 2.5.2, etc) but prevent new checks to be run during unrelated code modifications in case of a new Pylint non-backward compatible release.

Currently, when pysparkling tests are green, there is no guarantee they will be a few days later.

Pylint 2.5.0 was released a few days ago (https://pypi.org/project/pylint/#history) so the version is currently up-to-date and it will make sense to upgrade it in dedicated PRs in the future.