### PR TITLE
Feat/spark session conf

### DIFF
--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -5,8 +5,8 @@ class RuntimeConfig(object):
     def set(self, key, value):
         self._conf[key] = value
 
-    def get(self, key):
-        return self._conf.get(key)
+    def get(self, key, default):
+        return self._conf.get(key, default)
 
     def unset(self, key):
         del self._conf[key]

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -12,6 +12,8 @@ class RuntimeConfig(object):
         self._checkType(key, "key")
         if default is _sentinel:
             return self._conf.get(key)
+        if default is not None:
+            self._checkType(default, "default")
         return self._conf.get(key, default)
 
     def unset(self, key):

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -9,19 +9,18 @@ class RuntimeConfig(object):
         self._conf[key] = value
 
     def get(self, key, default=_sentinel):
+        self._checkType(key, "key")
         if default is _sentinel:
             return self._conf.get(key)
-        if default is not None:
-            self._checkType(default, "default")
         return self._conf.get(key, default)
+
+    def unset(self, key):
+        del self._conf[key]
 
     def _checkType(self, obj, identifier):
         if not isinstance(obj, str):
             raise TypeError("expected %s '%s' to be a string (was '%s')" %
                             (identifier, obj, type(obj).__name__))
-
-    def unset(self, key):
-        del self._conf[key]
 
     def isModifiable(self, key):
         raise NotImplementedError("pysparkling does not support yet this feature")

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -1,0 +1,15 @@
+class RuntimeConfig(object):
+    def __init__(self, jconf=None):
+        self._conf = {}
+
+    def set(self, key, value):
+        self._conf[key] = value
+
+    def get(self, key):
+        return self._conf.get(key)
+
+    def unset(self, key):
+        del self._conf[key]
+
+    def isModifiable(self, key):
+        raise NotImplementedError("pysparkling does not support yet this feature")

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -1,3 +1,6 @@
+_sentinel = object()
+
+
 class RuntimeConfig(object):
     def __init__(self, jconf=None):
         self._conf = {}
@@ -5,8 +8,17 @@ class RuntimeConfig(object):
     def set(self, key, value):
         self._conf[key] = value
 
-    def get(self, key, default):
+    def get(self, key, default=_sentinel):
+        if default is _sentinel:
+            return self._conf.get(key)
+        if default is not None:
+            self._checkType(default, "default")
         return self._conf.get(key, default)
+
+    def _checkType(self, obj, identifier):
+        if not isinstance(obj, str):
+            raise TypeError("expected %s '%s' to be a string (was '%s')" %
+                            (identifier, obj, type(obj).__name__))
 
     def unset(self, key):
         del self._conf[key]

--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,12 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # workaround: nosetests don't exit cleanly with older
 # python version (<=2.6 and even <2.7.4)
@@ -17,15 +17,7 @@ with open('pysparkling/__init__.py', 'r') as f:
 setup(
     name='pysparkling',
     version=VERSION,
-    packages=[
-        'pysparkling',
-        'pysparkling.sql',
-        'pysparkling.fileio',
-        'pysparkling.fileio.fs',
-        'pysparkling.fileio.codec',
-        'pysparkling.streaming',
-        'pysparkling.tests',
-    ],
+    packages=find_packages(),
     license='MIT',
     description='Pure Python implementation of the Spark RDD interface.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
This PR adds a Configuration object that will be used by SparkSession, the `spark` object class introduce in Spark 2.

Note: This PR is on top of #105, and contain additional modifications, it might be better to merge the previous one first to ease the review
