### PR TITLE
Feat/spark sql session

### DIFF
--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -5,8 +5,8 @@ class RuntimeConfig(object):
     def set(self, key, value):
         self._conf[key] = value
 
-    def get(self, key):
-        return self._conf.get(key)
+    def get(self, key, default):
+        return self._conf.get(key, default)
 
     def unset(self, key):
         del self._conf[key]

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -12,6 +12,8 @@ class RuntimeConfig(object):
         self._checkType(key, "key")
         if default is _sentinel:
             return self._conf.get(key)
+        if default is not None:
+            self._checkType(default, "default")
         return self._conf.get(key, default)
 
     def unset(self, key):

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -9,19 +9,18 @@ class RuntimeConfig(object):
         self._conf[key] = value
 
     def get(self, key, default=_sentinel):
+        self._checkType(key, "key")
         if default is _sentinel:
             return self._conf.get(key)
-        if default is not None:
-            self._checkType(default, "default")
         return self._conf.get(key, default)
+
+    def unset(self, key):
+        del self._conf[key]
 
     def _checkType(self, obj, identifier):
         if not isinstance(obj, str):
             raise TypeError("expected %s '%s' to be a string (was '%s')" %
                             (identifier, obj, type(obj).__name__))
-
-    def unset(self, key):
-        del self._conf[key]
 
     def isModifiable(self, key):
         raise NotImplementedError("pysparkling does not support yet this feature")

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -1,0 +1,15 @@
+class RuntimeConfig(object):
+    def __init__(self, jconf=None):
+        self._conf = {}
+
+    def set(self, key, value):
+        self._conf[key] = value
+
+    def get(self, key):
+        return self._conf.get(key)
+
+    def unset(self, key):
+        del self._conf[key]
+
+    def isModifiable(self, key):
+        raise NotImplementedError("pysparkling does not support yet this feature")

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -1,3 +1,6 @@
+_sentinel = object()
+
+
 class RuntimeConfig(object):
     def __init__(self, jconf=None):
         self._conf = {}
@@ -5,8 +8,17 @@ class RuntimeConfig(object):
     def set(self, key, value):
         self._conf[key] = value
 
-    def get(self, key, default):
+    def get(self, key, default=_sentinel):
+        if default is _sentinel:
+            return self._conf.get(key)
+        if default is not None:
+            self._checkType(default, "default")
         return self._conf.get(key, default)
+
+    def _checkType(self, obj, identifier):
+        if not isinstance(obj, str):
+            raise TypeError("expected %s '%s' to be a string (was '%s')" %
+                            (identifier, obj, type(obj).__name__))
 
     def unset(self, key):
         del self._conf[key]

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -1,7 +1,8 @@
 import sys
 from threading import RLock
 
-from pysparkling.sql.types import StructType, _create_converter, _infer_schema, _has_nulltype, _merge_type
+from pysparkling.sql.types import StructType, _create_converter, _infer_schema, \
+    _has_nulltype, _merge_type
 
 import pysparkling
 from pysparkling.context import Context
@@ -167,9 +168,11 @@ class SparkSession(object):
             data = list(data)
 
         if schema is None or isinstance(schema, (list, tuple)):
-            raise NotImplementedError("Implementation requires schema utils that are not yet merged")
+            raise NotImplementedError(
+                "Implementation requires schema utils that are not yet merged"
+            )
 
-        elif not isinstance(schema, StructType):
+        if not isinstance(schema, StructType):
             raise TypeError("schema should be StructType or list or None, but got: %s" % schema)
 
         # convert python objects to sql data
@@ -213,7 +216,9 @@ class SparkSession(object):
         return [r.tolist() for r in np_records]
 
     def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True):
-        raise NotImplementedError("This method implementation requires DataFrame which are not yet merged")
+        raise NotImplementedError(
+            "This method implementation requires DataFrame which are not yet merged"
+        )
 
     def parse_pandas_dataframe(self, data, schema):
         require_minimum_pandas_version()
@@ -235,8 +240,12 @@ class SparkSession(object):
         if numPartitions is None:
             numPartitions = self._sc.defaultParallelism
 
-        raise NotImplementedError("This method implementation requires DataFrame which are not yet merged")
+        raise NotImplementedError(
+            "This method implementation requires DataFrame which are not yet merged"
+        )
 
     @property
     def read(self):
-        raise NotImplementedError("This method implementation requires DataFrameReader which are not yet merged")
+        raise NotImplementedError(
+            "This method implementation requires DataFrameReader which are not yet merged"
+        )

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -1,0 +1,242 @@
+import sys
+from threading import RLock
+
+from pysparkling.sql.types import StructType, _create_converter, _infer_schema, _has_nulltype, _merge_type
+
+import pysparkling
+from pysparkling.context import Context
+from pysparkling.sql.conf import RuntimeConfig
+from pysparkling.sql.utils import require_minimum_pandas_version
+
+if sys.version >= '3':
+    basestring = unicode = str
+    xrange = range
+else:
+    import itertools as _itertools
+
+    # pylint: disable=W0622
+    map = getattr(_itertools, "imap")
+
+
+class SparkSession(object):
+    class Builder(object):
+        _lock = RLock()
+
+        def getOrCreate(self):
+            with self._lock:
+                session = SparkSession._instantiatedSession
+                if session is None:
+                    session = SparkSession(Context())
+                return session
+
+    _instantiatedSession = None
+    _activeSession = None
+
+    builder = Builder()
+
+    def __init__(self, sparkContext, jsparkSession=None):
+        # Top level import would cause cyclic dependencies
+        # pylint: disable=import-outside-toplevel
+        # from pysparkling.sql.context import SQLContext
+        self._sc = sparkContext
+        # self._wrapped = SQLContext(self._sc, self)
+        SparkSession._instantiatedSession = self
+        SparkSession._activeSession = self
+
+    def newSession(self):
+        """
+        Returns a new SparkSession as new session, that has separate SQLConf,
+        registered temporary views and UDFs, but shared SparkContext and
+        table cache.
+        """
+        return self.__class__(self._sc)
+
+    @classmethod
+    def getActiveSession(cls):
+        return SparkSession._activeSession
+
+    @property
+    def sparkContext(self):
+        """Returns the underlying Context."""
+        return self._sc
+
+    @property
+    def version(self):
+        return pysparkling.__version__
+
+    @property
+    def conf(self):
+        """Runtime configuration interface for Spark.
+
+        This is the interface through which the user can get and set all Spark and Hadoop
+        configurations that are relevant to Spark SQL. When getting the value of a config,
+        this defaults to the value set in the underlying :class:`SparkContext`, if any.
+        """
+        if not hasattr(self, "_conf"):
+            # Compatibility with Pyspark behavior
+            # noinspection PyAttributeOutsideInit
+            # pylint: disable=W0201
+            self._conf = RuntimeConfig()
+        return self._conf
+
+    @property
+    def catalog(self):
+        """Interface through which the user may create, drop, alter or query underlying
+        databases, tables, functions etc.
+
+        :return: :class:`Catalog`
+        """
+        # from pysparkling.sql.catalog import Catalog
+        # if not hasattr(self, "_catalog"):
+        #     # Compatibility with Pyspark behavior
+        #     # noinspection PyAttributeOutsideInit
+        #     self._catalog = Catalog(self)
+        # return self._catalog
+
+    @property
+    def udf(self):
+        # pylint: disable=W0511
+        # todo: Add support of udf registration
+        raise NotImplementedError("Pysparkling does not support yet catalog")
+        # from pysparkling.sql.udf import UDFRegistration
+        # return UDFRegistration(self)
+
+    def _inferSchema(self, rdd, samplingRatio=None, names=None):
+        """
+        Infer schema from an RDD of Row or tuple.
+
+        :param rdd: an RDD of Row or tuple
+        :param samplingRatio: sampling ratio, or no sampling (default)
+        :return: :class:`pysparkling.sql.types.StructType`
+        """
+        first = rdd.first()
+        if not first:
+            raise ValueError("The first row in RDD is empty, "
+                             "can not infer schema")
+        if isinstance(first, dict):
+            raise NotImplementedError(
+                "Using RDD of dict to inferSchema is deprecated in Spark "
+                "and not implemented in pysparkling. "
+                "Please use .sql.Row instead"
+            )
+
+        if samplingRatio is None:
+            schema = _infer_schema(first, names=names)
+            if _has_nulltype(schema):
+                for row in rdd.take(100)[1:]:
+                    schema = _merge_type(schema, _infer_schema(row, names=names))
+                    if not _has_nulltype(schema):
+                        break
+                else:
+                    raise ValueError("Some of types cannot be determined by the "
+                                     "first 100 rows, please try again with sampling")
+        else:
+            if samplingRatio < 0.99:
+                rdd = rdd.sample(False, float(samplingRatio))
+            schema = rdd.map(lambda r: _infer_schema(r, names)).reduce(_merge_type)
+        return schema
+
+    def _createFromRDD(self, rdd, schema, samplingRatio):
+        """
+        Create an RDD for DataFrame from an existing RDD, returns the RDD and schema.
+        """
+        if schema is None or isinstance(schema, (list, tuple)):
+            struct = self._inferSchema(rdd, samplingRatio, names=schema)
+            converter = _create_converter(struct)
+            rdd = rdd.map(converter)
+            if isinstance(schema, (list, tuple)):
+                for i, name in enumerate(schema):
+                    struct.fields[i].name = name
+                    struct.names[i] = name
+            schema = struct
+
+        elif not isinstance(schema, StructType):
+            raise TypeError("schema should be StructType or list or None, but got: %s" % schema)
+
+        # convert python objects to sql data
+        rdd = rdd.map(schema.toInternal)
+        return rdd, schema
+
+    def _createFromLocal(self, data, schema):
+        """
+        Create an RDD for DataFrame from a list or pandas.DataFrame, returns
+        the RDD and schema.
+        """
+        # make sure data could consumed multiple times
+        if not isinstance(data, list):
+            data = list(data)
+
+        if schema is None or isinstance(schema, (list, tuple)):
+            raise NotImplementedError("Implementation requires schema utils that are not yet merged")
+
+        elif not isinstance(schema, StructType):
+            raise TypeError("schema should be StructType or list or None, but got: %s" % schema)
+
+        # convert python objects to sql data
+        data = [schema.toInternal(row) for row in data]
+        return self._sc.parallelize(data), schema
+
+    # noinspection PyMethodMayBeStatic
+    def _get_numpy_record_dtype(self, rec):
+        # numpy is an optional dependency
+        # pylint: disable=import-outside-toplevel
+        import numpy as np
+        cur_dtypes = rec.dtype
+        col_names = cur_dtypes.names
+        record_type_list = []
+        has_rec_fix = False
+        for i, field in enumerate(cur_dtypes.fields.values()):
+            curr_type = field[0]
+            # If type is a datetime64 timestamp, convert to microseconds
+            # NOTE: if dtype is datetime[ns] then np.record.tolist() will output values as longs,
+            # conversion from [us] or lower will lead to py datetime objects, see SPARK-22417
+            if curr_type == np.dtype('datetime64[ns]'):
+                curr_type = 'datetime64[us]'
+                has_rec_fix = True
+            record_type_list.append((str(col_names[i]), curr_type))
+        return np.dtype(record_type_list) if has_rec_fix else None
+
+    def _convert_from_pandas(self, pdf, schema, timezone):
+        if timezone is not None:
+            raise NotImplementedError("Pandas with session timezone respect is not supported")
+
+        # Convert pandas.DataFrame to list of numpy records
+        np_records = pdf.to_records(index=False)
+
+        # Check if any columns need to be fixed for Spark to infer properly
+        if np_records.size > 0:
+            record_dtype = self._get_numpy_record_dtype(np_records[0])
+            if record_dtype is not None:
+                return [r.astype(record_dtype).tolist() for r in np_records]
+
+        # Convert list of numpy records to python lists
+        return [r.tolist() for r in np_records]
+
+    def createDataFrame(self, data, schema=None, samplingRatio=None, verifySchema=True):
+        raise NotImplementedError("This method implementation requires DataFrame which are not yet merged")
+
+    def parse_pandas_dataframe(self, data, schema):
+        require_minimum_pandas_version()
+        # pylint: disable=W0511
+        # todo: Add support of pandasRespectSessionTimeZone
+        # if self._wrapped._conf.pandasRespectSessionTimeZone():
+        #     timezone = self._wrapped._conf.sessionLocalTimeZone()
+        # else:
+        timezone = None
+        # If no schema supplied by user then get the names of columns only
+        if schema is None:
+            schema = [str(x) if not isinstance(x, basestring) else
+                      (x.encode('utf-8') if not isinstance(x, str) else x)
+                      for x in data.columns]
+        data = self._convert_from_pandas(data, schema, timezone)
+        return data, schema
+
+    def range(self, start, end=None, step=1, numPartitions=None):
+        if numPartitions is None:
+            numPartitions = self._sc.defaultParallelism
+
+        raise NotImplementedError("This method implementation requires DataFrame which are not yet merged")
+
+    @property
+    def read(self):
+        raise NotImplementedError("This method implementation requires DataFrameReader which are not yet merged")

--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,12 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # workaround: nosetests don't exit cleanly with older
 # python version (<=2.6 and even <2.7.4)
@@ -17,15 +17,7 @@ with open('pysparkling/__init__.py', 'r') as f:
 setup(
     name='pysparkling',
     version=VERSION,
-    packages=[
-        'pysparkling',
-        'pysparkling.sql',
-        'pysparkling.fileio',
-        'pysparkling.fileio.fs',
-        'pysparkling.fileio.codec',
-        'pysparkling.streaming',
-        'pysparkling.tests',
-    ],
+    packages=find_packages(),
     license='MIT',
     description='Pure Python implementation of the Spark RDD interface.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
This PR adds the SparkSession class, of which the `spark` variable (quite often used in Spark/PySpark 2 shells) is an instance.

It is the main entrypoint of most program as it gives access to DataFrame creation, either from an external datasource (`spark.read...`) or from a range (`spark.range(...)`) or from an existing Python object (`spark.createDataFrame`).

Most of these methods implementation are not part of this PR as they require the DataFrame object that will come soon.

Note: This PR is on top of #106, and contain additional modifications, it might be better to merge the previous one first to ease the review