### PR TITLE
Unify expression parameters

### DIFF
--- a/pysparkling/sql/column.py
+++ b/pysparkling/sql/column.py
@@ -83,7 +83,7 @@ class Column(object):
         return Column(Equal(self, parse_operator(other)))
 
     def __ne__(self, other):
-        return Column(Negate(Equal(self, parse_operator(other))))
+        return Column(Invert(Equal(self, parse_operator(other))))
 
     def __lt__(self, other):
         return Column(LessThan(self, parse_operator(other)))

--- a/pysparkling/sql/column.py
+++ b/pysparkling/sql/column.py
@@ -9,7 +9,7 @@ from pysparkling.sql.expressions.operators import Negate, Add, Minus, Time, Divi
 from pysparkling.sql.expressions.orders import DescNullsLast, DescNullsFirst, Desc, \
     AscNullsLast, AscNullsFirst, Asc, SortOrder
 from pysparkling.sql.types import string_to_type, DataType, StructField
-from pysparkling.sql.utils import IllegalArgumentException
+from pysparkling.sql.utils import IllegalArgumentException, AnalysisException
 
 
 class Column(object):
@@ -253,7 +253,7 @@ class Column(object):
                 "startPos and length must be the same type. "
                 "Got {0} and {1}, respectively.".format(type(startPos), type(length))
             )
-        return Column(Substring(self, startPos, length))
+        return Column(Substring(self, parse_operator(startPos), parse_operator(length)))
 
     def isin(self, *exprs):
         """
@@ -273,7 +273,8 @@ class Column(object):
         """
         if len(exprs) == 1 and isinstance(exprs[0], (list, set)):
             exprs = exprs[0]
-        return Column(IsIn(self, exprs))
+        values = [Literal(value) for value in exprs]
+        return Column(IsIn(self, values))
 
     def asc(self):
         """
@@ -468,7 +469,7 @@ class Column(object):
             raise ValueError('Pysparkling does not support alias with metadata')
 
         if len(alias) == 1:
-            return Column(Alias(self, alias[0]))
+            return Column(Alias(self, Literal(alias[0])))
         # pylint: disable=W0511
         # todo: support it
         raise ValueError('Pysparkling does not support multiple aliases')
@@ -699,6 +700,11 @@ class Column(object):
     def __repr__(self):
         return "Column<{0!r}>".format(self.expr)
 
+    def get_literal_value(self):
+        if isinstance(self.expr, Expression):
+            return self.expr.get_literal_value()
+        raise AnalysisException("Expecting a Literal, but got {0}: {1}".format(type(self), self))
+
 
 def parse(arg):
     """
@@ -711,6 +717,20 @@ def parse(arg):
     if isinstance(arg, (str, Expression)):
         return Column(arg)
     return Literal(value=arg)
+
+
+def ensure_column(arg):
+    """
+    Ensure that a value is a Column or a string and returns a Column corresponding to it
+    :rtype: Column
+    """
+    if isinstance(arg, Column):
+        return arg
+    if isinstance(arg, str):
+        return Column(arg)
+    raise TypeError("Invalid argument, not a string or column: {0} of type {1}. "
+                    "For column literals, use 'lit', 'array', 'struct' or 'create_map' function."
+                    .format(arg, type(arg)))
 
 
 def parse_operator(arg):

--- a/pysparkling/sql/expressions/aggregate/collectors.py
+++ b/pysparkling/sql/expressions/aggregate/collectors.py
@@ -65,7 +65,7 @@ class First(Aggregation):
         super(First, self).__init__(column)
         self.column = column
         self.value = self._sentinel
-        self.ignore_nulls = ignore_nulls
+        self.ignore_nulls = ignore_nulls.get_literal_value()
 
     def merge(self, row, schema):
         if self.value is First._sentinel or (self.ignore_nulls and self.value is None):
@@ -89,7 +89,7 @@ class Last(Aggregation):
         super(Last, self).__init__(column)
         self.column = column
         self.value = None
-        self.ignore_nulls = ignore_nulls
+        self.ignore_nulls = ignore_nulls.get_literal_value()
 
     def merge(self, row, schema):
         new_value = self.column.eval(row, schema)

--- a/pysparkling/sql/expressions/arrays.py
+++ b/pysparkling/sql/expressions/arrays.py
@@ -25,7 +25,7 @@ class ArraysOverlap(Expression):
 class ArrayContains(Expression):
     def __init__(self, array, value):
         self.array = array
-        self.value = value  # not a column
+        self.value = value.get_literal_value()
         super(ArrayContains, self).__init__(array)
 
     def eval(self, row, schema):
@@ -126,24 +126,24 @@ class ArrayMax(UnaryExpression):
 
 
 class Slice(Expression):
-    def __init__(self, x, start, length):
-        self.x = x
-        self.start = start
-        self.length = length
-        super(Slice, self).__init__(x)
+    def __init__(self, column, start, length):
+        self.column = column
+        self.start = start.get_literal_value()
+        self.length = length.get_literal_value()
+        super(Slice, self).__init__(column)
 
     def eval(self, row, schema):
-        return self.x.eval(row, schema)[self.start, self.start + self.length]
+        return self.column.eval(row, schema)[self.start, self.start + self.length]
 
     def __str__(self):
-        return "slice({0}, {1}, {2})".format(self.x, self.start, self.length)
+        return "slice({0}, {1}, {2})".format(self.column, self.start, self.length)
 
 
 class ArrayRepeat(Expression):
     def __init__(self, col, count):
         super(ArrayRepeat, self).__init__(col)
         self.col = col
-        self.count = count
+        self.count = count.get_literal_value()
 
     def eval(self, row, schema):
         value = self.col.eval(row, schema)
@@ -194,8 +194,8 @@ class ArrayJoin(Expression):
     def __init__(self, column, delimiter, nullReplacement):
         super(ArrayJoin, self).__init__(column)
         self.column = column
-        self.delimiter = delimiter
-        self.nullReplacement = nullReplacement
+        self.delimiter = delimiter.get_literal_value()
+        self.nullReplacement = nullReplacement.get_literal_value()
 
     def eval(self, row, schema):
         column_eval = self.column.eval(row, schema)
@@ -217,7 +217,7 @@ class SortArray(Expression):
     def __init__(self, col, asc):
         super(SortArray, self).__init__(col)
         self.col = col
-        self.asc = asc
+        self.asc = asc.get_literal_value()
 
     def eval(self, row, schema):
         return sorted(self.col.eval(row, schema), reverse=not self.asc)
@@ -262,7 +262,7 @@ class ArrayPosition(Expression):
     def __init__(self, col, value):
         super(ArrayPosition, self).__init__(col)
         self.col = col
-        self.value = value
+        self.value = value.get_literal_value()
 
     def eval(self, row, schema):
         if self.value is None:
@@ -281,7 +281,7 @@ class ElementAt(Expression):
     def __init__(self, col, extraction):
         super(ElementAt, self).__init__(col)
         self.col = col
-        self.extraction = extraction
+        self.extraction = extraction.get_literal_value()
 
     def eval(self, row, schema):
         col_eval = self.col.eval(row, schema)
@@ -297,7 +297,7 @@ class ArrayRemove(Expression):
     def __init__(self, col, element):
         super(ArrayRemove, self).__init__(col, element)
         self.col = col
-        self.element = element
+        self.element = element.get_literal_value()
 
     def eval(self, row, schema):
         array = self.col.eval(row, schema)

--- a/pysparkling/sql/expressions/dates.py
+++ b/pysparkling/sql/expressions/dates.py
@@ -17,11 +17,11 @@ class AddMonths(Expression):
     def __init__(self, start_date, num_months):
         super(AddMonths, self).__init__(start_date)
         self.start_date = start_date
-        self.num_months = num_months
+        self.num_months = num_months.get_literal_value()
+        self.timedelta = datetime.timedelta(days=self.num_months)
 
     def eval(self, row, schema):
-        return (self.start_date.cast(DateType()).eval(row, schema)
-                + relativedelta(months=self.num_months))
+        return self.start_date.cast(DateType()).eval(row, schema) + self.timedelta
 
     def __str__(self):
         return "add_months({0}, {1})".format(self.start_date, self.num_months)
@@ -31,8 +31,8 @@ class DateAdd(Expression):
     def __init__(self, start_date, num_days):
         super(DateAdd, self).__init__(start_date)
         self.start_date = start_date
-        self.num_days = num_days
-        self.timedelta = datetime.timedelta(days=num_days)
+        self.num_days = num_days.get_literal_value()
+        self.timedelta = datetime.timedelta(days=self.num_days)
 
     def eval(self, row, schema):
         return self.start_date.cast(DateType()).eval(row, schema) + self.timedelta
@@ -45,8 +45,8 @@ class DateSub(Expression):
     def __init__(self, start_date, num_days):
         super(DateSub, self).__init__(start_date)
         self.start_date = start_date
-        self.num_days = num_days
-        self.timedelta = datetime.timedelta(days=num_days)
+        self.num_days = num_days.get_literal_value()
+        self.timedelta = datetime.timedelta(days=self.num_days)
 
     def eval(self, row, schema):
         return self.start_date.cast(DateType()).eval(row, schema) - self.timedelta
@@ -153,7 +153,7 @@ class NextDay(Expression):
     def __init__(self, column, day_of_week):
         super(NextDay, self).__init__(column)
         self.column = column
-        self.day_of_week = day_of_week
+        self.day_of_week = day_of_week.get_literal_value()
 
     def eval(self, row, schema):
         value = self.column.cast(DateType()).eval(row, schema)
@@ -177,7 +177,7 @@ class MonthsBetween(Expression):
         super(MonthsBetween, self).__init__(column1, column2)
         self.column1 = column1
         self.column2 = column2
-        self.round_off = round_off
+        self.round_off = round_off.get_literal_value()
 
     def eval(self, row, schema):
         value_1 = self.column1.cast(TimestampType()).eval(row, schema)
@@ -241,7 +241,7 @@ class FromUnixTime(Expression):
     def __init__(self, column, f):
         super(FromUnixTime, self).__init__(column)
         self.column = column
-        self.format = f
+        self.format = f.get_literal_value()
         self.formatter = get_time_formatter(self.format)
 
     def eval(self, row, schema):
@@ -256,7 +256,7 @@ class DateFormat(Expression):
     def __init__(self, column, f):
         super(DateFormat, self).__init__(column)
         self.column = column
-        self.format = f
+        self.format = f.get_literal_value()
         self.formatter = get_time_formatter(self.format)
 
     def eval(self, row, schema):
@@ -303,7 +303,7 @@ class UnixTimestamp(Expression):
     def __init__(self, column, f):
         super(UnixTimestamp, self).__init__(column)
         self.column = column
-        self.format = f
+        self.format = f.get_literal_value()
         self.parser = get_unix_timestamp_parser(self.format)
 
     def eval(self, row, schema):
@@ -318,7 +318,7 @@ class ParseToTimestamp(Expression):
     def __init__(self, column, f):
         super(ParseToTimestamp, self).__init__(column)
         self.column = column
-        self.format = f
+        self.format = f.get_literal_value()
         self.parser = get_unix_timestamp_parser(self.format)
 
     def eval(self, row, schema):
@@ -336,7 +336,7 @@ class ParseToDate(Expression):
     def __init__(self, column, f):
         super(ParseToDate, self).__init__(column)
         self.column = column
-        self.format = f
+        self.format = f.get_literal_value()
         self.parser = get_unix_timestamp_parser(self.format)
 
     def eval(self, row, schema):
@@ -354,7 +354,7 @@ class TruncDate(Expression):
     def __init__(self, column, level):
         super(TruncDate, self).__init__(column)
         self.column = column
-        self.level = level
+        self.level = level.get_literal_value()
 
     def eval(self, row, schema):
         value = self.column.cast(DateType()).eval(row, schema)
@@ -371,8 +371,8 @@ class TruncDate(Expression):
 class TruncTimestamp(Expression):
     def __init__(self, level, column):
         super(TruncTimestamp, self).__init__(column)
+        self.level = level.get_literal_value()
         self.column = column
-        self.level = level
 
     def eval(self, row, schema):
         value = self.column.cast(TimestampType()).eval(row, schema)
@@ -422,8 +422,8 @@ class FromUTCTimestamp(Expression):
     def __init__(self, column, tz):
         super(FromUTCTimestamp, self).__init__(column)
         self.column = column
-        self.tz = tz
-        self.pytz = parse_tz(tz)
+        self.tz = tz.get_literal_value()
+        self.pytz = parse_tz(self.tz)
 
     def eval(self, row, schema):
         value = self.column.cast(TimestampType()).eval(row, schema)
@@ -441,8 +441,8 @@ class ToUTCTimestamp(Expression):
     def __init__(self, column, tz):
         super(ToUTCTimestamp, self).__init__(column)
         self.column = column
-        self.tz = tz
-        self.pytz = parse_tz(tz)
+        self.tz = tz.get_literal_value()
+        self.pytz = parse_tz(self.tz)
 
     def eval(self, row, schema):
         value = self.column.cast(TimestampType()).eval(row, schema)

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -136,6 +136,9 @@ class Expression(object):
             elif isinstance(child, (list, set, tuple)):
                 Expression.children_pre_evaluation_schema(child, schema)
 
+    def get_literal_value(self):
+        raise AnalysisException("Expecting a Literal, but got {0}: {1}".format(type(self), self))
+
 
 class UnaryExpression(Expression):
     def __init__(self, column):

--- a/pysparkling/sql/expressions/literals.py
+++ b/pysparkling/sql/expressions/literals.py
@@ -1,4 +1,5 @@
 from pysparkling.sql.expressions.expressions import Expression
+from pysparkling.sql.utils import AnalysisException
 
 
 class Literal(Expression):
@@ -11,6 +12,12 @@ class Literal(Expression):
 
     def __str__(self):
         return str(self.value)
+
+    def get_literal_value(self):
+        if hasattr(self.value, "expr") or isinstance(self.value, Expression):
+            raise AnalysisException("Value should not be a Column or an Expression, "
+                                    "but got {0}: {1}".format(type(self), self))
+        return self.value
 
 
 __all__ = ["Literal"]

--- a/pysparkling/sql/expressions/literals.py
+++ b/pysparkling/sql/expressions/literals.py
@@ -11,6 +11,12 @@ class Literal(Expression):
         return self.value
 
     def __str__(self):
+        if self.value is True:
+            return "true"
+        if self.value is False:
+            return "false"
+        if self.value is None:
+            return "NULL"
         return str(self.value)
 
     def get_literal_value(self):

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -548,6 +548,45 @@ class Bin(UnaryExpression):
         return "bin({0})".format(self.column)
 
 
+class ShiftLeft(Expression):
+    def __init__(self, arg, num_bits):
+        super(ShiftLeft, self).__init__(arg)
+        self.arg = arg
+        self.num_bits = num_bits.get_literal_value()
+
+    def eval(self, row, schema):
+        return self.arg.eval(row, schema) << self.num_bits
+
+    def __str__(self):
+        return "shiftleft({0}, {1})".format(self.arg, self.num_bits)
+
+
+class ShiftRight(Expression):
+    def __init__(self, arg, num_bits):
+        super(ShiftRight, self).__init__(arg)
+        self.arg = arg
+        self.num_bits = num_bits.get_literal_value()
+
+    def eval(self, row, schema):
+        return self.arg.eval(row, schema) >> self.num_bits
+
+    def __str__(self):
+        return "shiftright({0}, {1})".format(self.arg, self.num_bits)
+
+
+class ShiftRightUnsigned(object):
+    def __init__(self, arg, num_bits):
+        super(ShiftRightUnsigned, self).__init__(arg)
+        self.arg = arg
+        self.num_bits = num_bits.get_literal_value()
+
+    def eval(self, row, schema):
+        return self.arg.eval(row, schema) >> self.num_bits
+
+    def __str__(self):
+        return "shiftright({0}, {1})".format(self.arg, self.num_bits)
+
+
 class Greatest(Expression):
     def __init__(self, columns):
         super(Greatest, self).__init__(columns)
@@ -927,5 +966,5 @@ __all__ = [
     "ToRadians", "Ascii", "Base64", "ConcatWs", "FormatNumber", "Length", "Lower",
     "RegExpExtract", "RegExpReplace", "UnBase64", "StringSplit", "SubstringIndex", "Upper",
     "Concat", "Reverse", "MapKeys", "MapValues", "MapEntries", "MapFromEntries",
-    "MapConcat", "StarOperator"
+    "MapConcat", "StarOperator", "ShiftLeft", "ShiftRight", "ShiftRightUnsigned"
 ]

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -537,7 +537,7 @@ class CreateStruct(Expression):
         return create_row(struct_cols, struct_values)
 
     def __str__(self):
-        return "named_struct({0})".format(", ".join("{0}, {0}".format(col) for col in self.columns))
+        return "struct({0})".format(", ".join(str(col) for col in self.columns))
 
 
 class Bin(UnaryExpression):

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -61,14 +61,6 @@ class Pow(NullSafeBinaryOperation):
         return "POWER({0}, {1})".format(self.arg1, self.arg2)
 
 
-class Pmod(NullSafeBinaryOperation):
-    def unsafe_operation(self, value1, value2):
-        return value1 % value2
-
-    def __str__(self):
-        return "pmod({0} % {1})".format(self.arg1, self.arg2)
-
-
 class Equal(TypeSafeBinaryOperation):
     def unsafe_operation(self, value_1, value_2):
         return value_1 == value_2
@@ -267,7 +259,7 @@ class IsIn(Expression):
     def __init__(self, arg1, cols):
         super(IsIn, self).__init__(arg1)
         self.arg1 = arg1
-        self.cols = cols
+        self.cols = [c.get_literal_value() for c in cols]
 
     def eval(self, row, schema):
         return self.arg1.eval(row, schema) in self.cols
@@ -315,8 +307,8 @@ class Substring(Expression):
     def __init__(self, expr, start, length):
         super(Substring, self).__init__(expr)
         self.expr = expr
-        self.start = start
-        self.length = length
+        self.start = start.get_literal_value()
+        self.length = length.get_literal_value()
 
     def eval(self, row, schema):
         return str(self.expr.eval(row, schema))[self.start - 1:self.start - 1 + self.length]
@@ -329,7 +321,7 @@ class Alias(Expression):
     def __init__(self, expr, alias):
         super(Alias, self).__init__(expr, alias)
         self.expr = expr
-        self.alias = alias
+        self.alias = alias.get_literal_value()
 
     @property
     def may_output_multiple_cols(self):
@@ -358,7 +350,6 @@ __all__ = [
     "Divide",
     "Mod",
     "Pow",
-    "Pmod",
     "Equal",
     "LessThan",
     "LessThanOrEqual",

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -302,6 +302,12 @@ class Cast(Expression):
     def __str__(self):
         return "{0}".format(self.column)
 
+    def __repr__(self):
+        return "CAST({0} AS {1})".format(
+            self.column,
+            self.destination_type.simpleString().upper()
+        )
+
 
 class Substring(Expression):
     def __init__(self, expr, start, length):

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -342,6 +342,14 @@ class Alias(Expression):
         return self.alias
 
 
+class UnaryPositive(UnaryExpression):
+    def eval(self, row, schema):
+        return self.column.eval(row, schema)
+
+    def __str__(self):
+        return "(+ {0})".format(self.column)
+
+
 __all__ = [
     "Negate",
     "Add",
@@ -372,5 +380,6 @@ __all__ = [
     "Cast",
     "Substring",
     "IsNull",
-    "Alias"
+    "Alias",
+    "UnaryPositive",
 ]

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -7,7 +7,7 @@ from pysparkling.sql.types import StructType
 
 class Negate(UnaryExpression):
     def eval(self, row, schema):
-        return not self.column.eval(row, schema)
+        return - self.column.eval(row, schema)
 
     def __str__(self):
         return "(- {0})".format(self.column)

--- a/pysparkling/sql/expressions/strings.py
+++ b/pysparkling/sql/expressions/strings.py
@@ -37,7 +37,10 @@ class StringInStr(Expression):
 
     def eval(self, row, schema):
         value = self.column.cast(StringType()).eval(row, schema)
-        return int(self.substr in value)
+        try:
+            return value.index(self.substr)
+        except IndexError:
+            return 0
 
     def __str__(self):
         return "instr({0}, {1})".format(

--- a/pysparkling/sql/expressions/strings.py
+++ b/pysparkling/sql/expressions/strings.py
@@ -30,10 +30,10 @@ class StringRTrim(UnaryExpression):
 
 
 class StringInStr(Expression):
-    def __init__(self, substr, column):
+    def __init__(self, column, substr):
         super(StringInStr, self).__init__(column)
-        self.substr = substr
         self.column = column
+        self.substr = substr.get_literal_value()
 
     def eval(self, row, schema):
         value = self.column.cast(StringType()).eval(row, schema)
@@ -41,17 +41,17 @@ class StringInStr(Expression):
 
     def __str__(self):
         return "instr({0}, {1})".format(
-            self.substr,
-            self.column
+            self.column,
+            self.substr
         )
 
 
 class StringLocate(Expression):
     def __init__(self, substr, column, pos):
         super(StringLocate, self).__init__(column)
-        self.substr = substr
+        self.substr = substr.get_literal_value()
         self.column = column
-        self.start = pos - 1
+        self.start = pos.get_literal_value() - 1
 
     def eval(self, row, schema):
         value = self.column.cast(StringType()).eval(row, schema)
@@ -71,8 +71,8 @@ class StringLPad(Expression):
     def __init__(self, column, length, pad):
         super(StringLPad, self).__init__(column)
         self.column = column
-        self.length = length
-        self.pad = pad
+        self.length = length.get_literal_value()
+        self.pad = pad.get_literal_value()
 
     def eval(self, row, schema):
         value = self.column.cast(StringType()).eval(row, schema)
@@ -92,8 +92,8 @@ class StringRPad(Expression):
     def __init__(self, column, length, pad):
         super(StringRPad, self).__init__(column)
         self.column = column
-        self.length = length
-        self.pad = pad
+        self.length = length.get_literal_value()
+        self.pad = pad.get_literal_value()
 
     def eval(self, row, schema):
         value = self.column.cast(StringType()).eval(row, schema)
@@ -113,7 +113,7 @@ class StringRepeat(Expression):
     def __init__(self, column, n):
         super(StringRepeat, self).__init__(column)
         self.column = column
-        self.n = n
+        self.n = n.get_literal_value()
 
     def eval(self, row, schema):
         value = self.column.cast(StringType()).eval(row, schema)
@@ -130,13 +130,13 @@ class StringTranslate(Expression):
     def __init__(self, column, matching_string, replace_string):
         super(StringTranslate, self).__init__(column)
         self.column = column
-        self.matching_string = matching_string
-        self.replace_string = replace_string
+        self.matching_string = matching_string.get_literal_value()
+        self.replace_string = replace_string.get_literal_value()
         self.translation_table = str.maketrans(
             # Python's translate use an opposite importance order as Spark
             # when there are duplicates in matching_string mapped to different chars
-            matching_string[::-1],
-            replace_string[::-1]
+            self.matching_string[::-1],
+            self.replace_string[::-1]
         )
 
     def eval(self, row, schema):

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -1,6 +1,6 @@
 import math
 
-from pysparkling.sql.column import Column, parse
+from pysparkling.sql.column import Column, parse, ensure_column
 from pysparkling.sql.expressions.aggregate.collectors import CollectSet, ApproxCountDistinct, \
     CollectList, CountDistinct, First, Last, SumDistinct
 from pysparkling.sql.expressions.aggregate.covariance_aggregations import Corr, CovarPop, CovarSamp
@@ -27,7 +27,7 @@ from pysparkling.sql.expressions.mappers import CaseWhen, Rand, CreateStruct, Gr
     SubstringIndex, Upper, Concat, Reverse, MapKeys, MapValues, MapEntries, MapFromEntries, \
     MapConcat
 from pysparkling.sql.expressions.literals import Literal
-from pysparkling.sql.expressions.operators import IsNull, BitwiseNot, Pow, Pmod, Substring
+from pysparkling.sql.expressions.operators import IsNull, BitwiseNot, Pow, Substring
 from pysparkling.sql.expressions.strings import InitCap, StringInStr, Levenshtein, StringLocate, \
     StringLPad, StringLTrim, StringRPad, StringRepeat, StringRTrim, SoundEx, StringTranslate, \
     StringTrim
@@ -302,7 +302,7 @@ def rand(seed=None):
     |0.8800146499990725|
     +------------------+
     """
-    return col(Rand(seed))
+    return col(Rand(parse(seed)))
 
 
 def randn(seed=None):
@@ -324,7 +324,7 @@ def randn(seed=None):
     |-5.552412872005739|
     +------------------+
     """
-    return col(Randn(seed))
+    return col(Randn(lit(seed)))
 
 
 def struct(*exprs):
@@ -437,14 +437,14 @@ def first(e, ignoreNulls=False):
     """
     :rtype: Column
     """
-    return col(First(parse(e), ignoreNulls))
+    return col(First(parse(e), lit(ignoreNulls)))
 
 
 def last(e, ignoreNulls=False):
     """
     :rtype: Column
     """
-    return col(Last(parse(e), ignoreNulls))
+    return col(Last(parse(e), lit(ignoreNulls)))
 
 
 def grouping(e):
@@ -887,7 +887,7 @@ def conv(num, fromBase, toBase):
     """
     :rtype: Column
     """
-    return col(Conv(parse(num), fromBase, toBase))
+    return col(Conv(parse(num), lit(fromBase), lit(toBase)))
 
 
 def cos(e):
@@ -981,7 +981,7 @@ def log(arg1, arg2=None):
         base, value = math.e, parse(arg1)
     else:
         base, value = arg1, parse(arg2)
-    return col(Log(base, value))
+    return col(Log(lit(base), value))
 
 
 def log10(e):
@@ -1012,14 +1012,6 @@ def pow(l, r):
     :rtype: Column
     """
     return col(Pow(parse(l), parse(r)))
-
-
-def pmod(dividend, divisor):
-    """
-    :rtype: Column
-    """
-    return col(Pmod(dividend, divisor))
-
 
 def rint(e):
     """
@@ -1053,7 +1045,7 @@ def round(e, scale=0):
 
 
     """
-    return col(Round(parse(e), scale))
+    return col(Round(parse(e), lit(scale)))
 
 
 def bround(e, scale=0):
@@ -1077,7 +1069,7 @@ def bround(e, scale=0):
     |           9.0|          10.0|          10.0|           8.0|            20|            20|
     +--------------+--------------+--------------+--------------+--------------+--------------+
     """
-    return col(Bround(parse(e), scale))
+    return col(Bround(parse(e), lit(scale)))
 
 
 def shiftLeft(e, numBits):
@@ -1226,7 +1218,7 @@ def concat_ws(sep, *exprs):
 
     """
     cols = [parse(e) for e in exprs]
-    return col(ConcatWs(sep, cols))
+    return col(ConcatWs(lit(sep), cols))
 
 
 def decode(value, charset):
@@ -1257,7 +1249,7 @@ def format_number(x, d):
     |                 1,000,000.873|
     +------------------------------+
     """
-    return col(FormatNumber(parse(x), d))
+    return col(FormatNumber(parse(x), lit(d)))
 
 
 # noinspection PyShadowingBuiltins
@@ -1292,7 +1284,7 @@ def instr(str, substring):
     """
     :rtype: Column
     """
-    return col(StringInStr(parse(str), substring))
+    return col(StringInStr(parse(str), lit(substring)))
 
 
 def length(e):
@@ -1333,7 +1325,7 @@ def locate(substr, str, pos=1):
     """
     :rtype: Column
     """
-    return col(StringLocate(substr, parse(str), pos))
+    return col(StringLocate(lit(substr), parse(str), lit(pos)))
 
 
 # noinspection PyShadowingBuiltins
@@ -1342,14 +1334,14 @@ def lpad(str, len, pad):
     """
     :rtype: Column
     """
-    return col(StringLPad(parse(str), len, pad))
+    return col(StringLPad(parse(str), lit(len), lit(pad)))
 
 
 def ltrim(e):
     """
     :rtype: Column
     """
-    return col(StringLTrim(e))
+    return col(StringLTrim(parse(e)))
 
 
 def regexp_extract(e, exp, groupIdx):
@@ -1360,14 +1352,12 @@ def regexp_extract(e, exp, groupIdx):
     >>> df = spark.createDataFrame([('100-200',)], ['str'])
     >>> df.collect()
     [Row(str='100-200')]
-    >>> df.select(Column('str').alias('range')).collect()
-    [Row(range='100-200')]
     >>> df.select(regexp_extract(df.str, r'(\\d+)-(\\d+)', 1).alias('d')).collect()
     [Row(d='100')]
 
     :rtype: Column
     """
-    return col(RegExpExtract(e, exp, groupIdx))
+    return col(RegExpExtract(parse(e), lit(exp), lit(groupIdx)))
 
 
 def regexp_replace(e, pattern, replacement):
@@ -1378,14 +1368,12 @@ def regexp_replace(e, pattern, replacement):
     >>> df = spark.createDataFrame([('100-200',)], ['str'])
     >>> df.collect()
     [Row(str='100-200')]
-    >>> df.select(Column('str').alias('range')).collect()
-    [Row(range='100-200')]
     >>> df.select(regexp_replace(df.str, r'-(\\d+)', '-300').alias('d')).collect()
     [Row(d='100-300')]
 
     :rtype: Column
     """
-    return col(RegExpReplace(e, pattern, replacement))
+    return col(RegExpReplace(parse(e), lit(pattern), lit(replacement)))
 
 
 def unbase64(e):
@@ -1407,7 +1395,7 @@ def rpad(str, len, pad):
     """
     :rtype: Column
     """
-    return col(StringRPad(parse(str), len, pad))
+    return col(StringRPad(parse(str), lit(len), lit(pad)))
 
 
 # noinspection PyShadowingBuiltins
@@ -1416,14 +1404,14 @@ def repeat(str, n):
     """
     :rtype: Column
     """
-    return col(StringRepeat(parse(str), n))
+    return col(StringRepeat(parse(str), lit(n)))
 
 
 def rtrim(e):
     """
     :rtype: Column
     """
-    return col(StringRTrim(e))
+    return col(StringRTrim(parse(e)))
 
 
 def soundex(e):
@@ -1464,7 +1452,7 @@ def split(str, regex, limit=None):
     """
     :rtype: Column
     """
-    return col(StringSplit(parse(str), regex, limit))
+    return col(StringSplit(parse(str), lit(regex), lit(limit)))
 
 
 # noinspection PyShadowingBuiltins
@@ -1473,7 +1461,7 @@ def substring(str, pos, len):
     """
     :rtype: Column
     """
-    return col(Substring(str, pos, len))
+    return col(Substring(str, lit(pos), lit(len)))
 
 
 # noinspection PyShadowingBuiltins
@@ -1509,14 +1497,14 @@ def substring_index(str, delim, count):
 
     :rtype: Column
     """
-    return col(SubstringIndex(parse(str), delim, count))
+    return col(SubstringIndex(parse(str), lit(delim), lit(count)))
 
 
 def translate(srcCol, matchingString, replaceString):
     """
     :rtype: Column
     """
-    return col(StringTranslate(parse(srcCol), matchingString, replaceString))
+    return col(StringTranslate(parse(srcCol), lit(matchingString), lit(replaceString)))
 
 
 def trim(e):
@@ -1530,14 +1518,14 @@ def upper(e):
     """
     :rtype: Column
     """
-    return col(Upper(e))
+    return col(Upper(parse(e)))
 
 
 def add_months(startDate, numMonths):
     """
     :rtype: Column
     """
-    return col(AddMonths(parse(startDate), numMonths))
+    return col(AddMonths(ensure_column(startDate), lit(numMonths)))
 
 
 def current_date():
@@ -1570,7 +1558,7 @@ def date_format(dateExpr, format):
     |                        10/31/2019|
     +----------------------------------+
     """
-    return col(DateFormat(parse(dateExpr), format))
+    return col(DateFormat(ensure_column(dateExpr), lit(format)))
 
 
 def date_add(start, days):
@@ -1588,7 +1576,7 @@ def date_add(start, days):
     +-----------------------+
 
     """
-    return col(DateAdd(parse(start), days))
+    return col(DateAdd(ensure_column(start), lit(days)))
 
 
 def date_sub(start, days):
@@ -1605,7 +1593,7 @@ def date_sub(start, days):
     |             2019-02-27|
     +-----------------------+
     """
-    return col(DateSub(parse(start), days))
+    return col(DateSub(ensure_column(start), lit(days)))
 
 
 def datediff(end, start):
@@ -1630,14 +1618,14 @@ def datediff(end, start):
     +--------------------------------+
 
     """
-    return col(DateDiff(end, start))
+    return col(DateDiff(ensure_column(end), ensure_column(start)))
 
 
 def year(e):
     """
     :rtype: Column
     """
-    return col(Year(e))
+    return col(Year(ensure_column(e)))
 
 
 def quarter(e):
@@ -1654,14 +1642,14 @@ def quarter(e):
     |                  2|
     +-------------------+
     """
-    return col(Quarter(e))
+    return col(Quarter(ensure_column(e)))
 
 
 def month(e):
     """
     :rtype: Column
     """
-    return col(Month(e))
+    return col(Month(ensure_column(e)))
 
 
 def dayofweek(e):
@@ -1691,14 +1679,14 @@ def dayofweek(e):
     +---+----------+---------+
 
     """
-    return col(DayOfWeek(parse(e)))
+    return col(DayOfWeek(ensure_column(e)))
 
 
 def dayofmonth(e):
     """
     :rtype: Column
     """
-    return col(DayOfMonth(e))
+    return col(DayOfMonth(ensure_column(e)))
 
 
 def dayofyear(e):
@@ -1728,14 +1716,14 @@ def dayofyear(e):
 
     :rtype: Column
     """
-    return col(DayOfYear(parse(e)))
+    return col(DayOfYear(ensure_column(e)))
 
 
 def hour(e):
     """
     :rtype: Column
     """
-    return col(Hour(e))
+    return col(Hour(ensure_column(e)))
 
 
 def last_day(e):
@@ -1752,14 +1740,14 @@ def last_day(e):
     |          2019-10-31|
     +--------------------+
     """
-    return col(LastDay(e))
+    return col(LastDay(ensure_column(e)))
 
 
 def minute(e):
     """
     :rtype: Column
     """
-    return col(Minute(e))
+    return col(Minute(ensure_column(e)))
 
 
 def months_between(end, start, roundOff=True):
@@ -1813,7 +1801,7 @@ def months_between(end, start, roundOff=True):
     |                                                                  3.0|
     +---------------------------------------------------------------------+
     """
-    return col(MonthsBetween(end, start, roundOff))
+    return col(MonthsBetween(ensure_column(end), ensure_column(start), lit(roundOff)))
 
 
 def next_day(date, dayOfWeek):
@@ -1838,21 +1826,21 @@ def next_day(date, dayOfWeek):
     |                          2019-11-11|
     +------------------------------------+
     """
-    return col(NextDay(parse(date), dayOfWeek))
+    return col(NextDay(ensure_column(date), lit(dayOfWeek)))
 
 
 def second(e):
     """
     :rtype: Column
     """
-    return col(Second(e))
+    return col(Second(ensure_column(e)))
 
 
 def weekofyear(e):
     """
     :rtype: Column
     """
-    return col(WeekOfYear(e))
+    return col(WeekOfYear(ensure_column(e)))
 
 
 def from_unixtime(ut, f="yyyy-MM-dd HH:mm:ss"):
@@ -1874,7 +1862,7 @@ def from_unixtime(ut, f="yyyy-MM-dd HH:mm:ss"):
     |                                  2033-05-18 05:33:23|
     +-----------------------------------------------------+
     """
-    return col(FromUnixTime(parse(ut), f))
+    return col(FromUnixTime(parse(ut), lit(f)))
 
 
 def unix_timestamp(s=None, p="yyyy-MM-dd HH:mm:ss"):
@@ -1901,8 +1889,8 @@ def unix_timestamp(s=None, p="yyyy-MM-dd HH:mm:ss"):
     +--------------------------------------+
     """
     if s is None:
-        s = CurrentTimestamp()
-    return col(UnixTimestamp(s, p))
+        s = col(CurrentTimestamp())
+    return col(UnixTimestamp(ensure_column(s), lit(p)))
 
 
 def to_timestamp(s, fmt=None):
@@ -1925,7 +1913,7 @@ def to_timestamp(s, fmt=None):
     |                     2019-01-01 00:00:00|
     +----------------------------------------+
     """
-    return col(ParseToTimestamp(s, fmt))
+    return col(ParseToTimestamp(ensure_column(s), lit(fmt)))
 
 
 def to_date(e, fmt=None):
@@ -1950,7 +1938,7 @@ def to_date(e, fmt=None):
     +-----------------------------------+
 
     """
-    return col(ParseToDate(e, fmt))
+    return col(ParseToDate(ensure_column(e), lit(fmt)))
 
 
 # noinspection PyShadowingBuiltins
@@ -1985,7 +1973,7 @@ def trunc(date, format):
 
 
     """
-    return col(TruncDate(parse(date), format))
+    return col(TruncDate(parse(date), lit(format)))
 
 
 # noinspection PyShadowingBuiltins
@@ -2019,7 +2007,7 @@ def date_trunc(format, timestamp):
     +---------------------------------------+
 
     """
-    return col(TruncTimestamp(format, parse(timestamp)))
+    return col(TruncTimestamp(lit(format), parse(timestamp)))
 
 
 def from_utc_timestamp(ts, tz):
@@ -2048,7 +2036,7 @@ def from_utc_timestamp(ts, tz):
     |                           2019-11-05 03:06:00|
     +----------------------------------------------+
     """
-    return col(FromUTCTimestamp(ts, tz))
+    return col(FromUTCTimestamp(ensure_column(ts), lit(tz)))
 
 
 def to_utc_timestamp(ts, tz):
@@ -2077,7 +2065,7 @@ def to_utc_timestamp(ts, tz):
     |                         2019-11-05 06:44:00|
     +--------------------------------------------+
     """
-    return col(ToUTCTimestamp(ts, tz))
+    return col(ToUTCTimestamp(ensure_column(ts), lit(tz)))
 
 
 def window(timeColumn, windowDuration, slideDuration=None, startTime="0 second"):
@@ -2088,7 +2076,7 @@ def array_contains(column, value):
     """
     :rtype: Column
     """
-    return col(ArrayContains(parse(column), value))
+    return col(ArrayContains(parse(column), lit(value)))
 
 
 def arrays_overlap(a1, a2):
@@ -2104,14 +2092,14 @@ def slice(x, start, length):
     """
     :rtype: Column
     """
-    return col(Slice(x, start, length))
+    return col(Slice(ensure_column(x), lit(start), lit(length)))
 
 
 def array_join(column, delimiter, nullReplacement=None):
     """
     :rtype: Column
     """
-    return col(ArrayJoin(column, delimiter, nullReplacement))
+    return col(ArrayJoin(ensure_column(column), lit(delimiter), lit(nullReplacement)))
 
 
 def concat(*exprs):
@@ -2126,35 +2114,35 @@ def array_position(column, value):
     """
     :rtype: Column
     """
-    return col(ArrayPosition(column, value))
+    return col(ArrayPosition(ensure_column(column), lit(value)))
 
 
 def element_at(column, value):
     """
     :rtype: Column
     """
-    return col(ElementAt(column, value))
+    return col(ElementAt(ensure_column(column), lit(value)))
 
 
 def array_sort(e):
     """
     :rtype: Column
     """
-    return col(ArraySort(e))
+    return col(ArraySort(ensure_column(e)))
 
 
 def array_remove(column, element):
     """
     :rtype: Column
     """
-    return col(ArrayRemove(column, element))
+    return col(ArrayRemove(ensure_column(column), lit(element)))
 
 
 def array_distinct(e):
     """
     :rtype: Column
     """
-    return col(ArrayDistinct(e))
+    return col(ArrayDistinct(ensure_column(e)))
 
 
 def array_intersect(col1, col2):
@@ -2189,21 +2177,21 @@ def explode_outer(e):
     """
     :rtype: Column
     """
-    return col(ExplodeOuter(e))
+    return col(ExplodeOuter(ensure_column(e)))
 
 
 def posexplode(e):
     """
     :rtype: Column
     """
-    return col(PosExplode(e))
+    return col(PosExplode(ensure_column(e)))
 
 
 def posexplode_outer(e):
     """
     :rtype: Column
     """
-    return col(PosExplodeOuter(e))
+    return col(PosExplodeOuter(ensure_column(e)))
 
 
 def get_json_object(e, path):
@@ -2285,21 +2273,21 @@ def sort_array(e, asc=True):
     """
     :rtype: Column
     """
-    return col(SortArray(parse(e), asc))
+    return col(SortArray(parse(e), lit(asc)))
 
 
 def array_min(e):
     """
     :rtype: Column
     """
-    return col(ArrayMin(e))
+    return col(ArrayMin(ensure_column(e)))
 
 
 def array_max(e):
     """
     :rtype: Column
     """
-    return col(ArrayMax(e))
+    return col(ArrayMax(ensure_column(e)))
 
 
 def shuffle(e):
@@ -2313,14 +2301,14 @@ def reverse(e):
     """
     :rtype: Column
     """
-    return col(Reverse(e))
+    return col(Reverse(ensure_column(e)))
 
 
 def flatten(e):
     """
     :rtype: Column
     """
-    return col(Flatten(parse(e)))
+    return col(Flatten(ensure_column(e)))
 
 
 def sequence(start, stop, step=None):
@@ -2338,35 +2326,35 @@ def array_repeat(e, count):
     """
     :rtype: Column
     """
-    return col(ArrayRepeat(parse(e), count))
+    return col(ArrayRepeat(parse(e), lit(count)))
 
 
 def map_keys(e):
     """
     :rtype: Column
     """
-    return col(MapKeys(e))
+    return col(MapKeys(ensure_column(e)))
 
 
 def map_values(e):
     """
     :rtype: Column
     """
-    return col(MapValues(e))
+    return col(MapValues(ensure_column(e)))
 
 
 def map_entries(e):
     """
     :rtype: Column
     """
-    return col(MapEntries(e))
+    return col(MapEntries(ensure_column(e)))
 
 
 def map_from_entries(e):
     """
     :rtype: Column
     """
-    return col(MapFromEntries(e))
+    return col(MapFromEntries(ensure_column(e)))
 
 
 def arrays_zip(*exprs):
@@ -2483,3 +2471,35 @@ def pandas_udf(f=None, returnType=None, functionType=None):
 
 def callUDF(udfName, *cols):
     raise NotImplementedError("Pysparkling does not support yet this function")
+
+
+__all__ = [
+    'abs', 'acos', 'add_months', 'approx_count_distinct', 'array', 'array_contains',
+    'array_distinct', 'array_except', 'array_intersect', 'array_join', 'array_max', 'array_min',
+    'array_position', 'array_remove', 'array_repeat', 'array_sort', 'array_union', 'arrays_overlap',
+    'arrays_zip', 'asc', 'asc_nulls_first', 'asc_nulls_last', 'ascii', 'asin', 'atan', 'atan2',
+    'avg', 'base64', 'bin', 'bitwiseNOT', 'broadcast', 'bround', 'callUDF', 'cbrt', 'ceil',
+    'coalesce', 'col', 'collect_list', 'collect_set', 'column', 'concat', 'concat_ws', 'conv',
+    'corr', 'cos', 'cosh', 'count', 'countDistinct', 'covar_pop', 'covar_samp', 'crc32',
+    'create_map', 'cume_dist', 'current_date', 'current_timestamp', 'date_add', 'date_format',
+    'date_sub', 'date_trunc', 'datediff', 'dayofmonth', 'dayofweek', 'dayofyear', 'decode',
+    'degrees', 'dense_rank', 'desc', 'desc_nulls_first', 'desc_nulls_last', 'element_at', 'encode',
+    'exp', 'explode', 'explode_outer', 'expm1', 'expr', 'factorial', 'first', 'flatten', 'floor',
+    'format_number', 'format_string', 'from_csv', 'from_json', 'from_unixtime',
+    'from_utc_timestamp', 'get_json_object', 'greatest', 'grouping', 'grouping_id', 'hash', 'hex',
+    'hour', 'hypot', 'initcap', 'input_file_name', 'instr', 'isnan', 'isnull', 'json_tuple',
+    'kurtosis', 'lag', 'last', 'last_day', 'lead', 'least', 'length', 'levenshtein', 'lit',
+    'locate', 'log', 'log10', 'log1p', 'log2', 'lower', 'lpad', 'ltrim', 'map_concat',
+    'map_entries', 'map_from_arrays', 'map_from_entries', 'map_keys', 'map_values', 'math', 'max',
+    'md5', 'mean', 'min', 'minute', 'monotonically_increasing_id', 'month', 'months_between',
+    'nanvl', 'next_day', 'ntile', 'pandas_udf', 'parse', 'percent_rank', 'posexplode',
+    'posexplode_outer', 'pow', 'quarter', 'radians', 'rand', 'randn', 'rank', 'regexp_extract',
+    'regexp_replace', 'repeat', 'reverse', 'rint', 'round', 'row_number', 'rpad', 'rtrim',
+    'schema_of_csv', 'schema_of_json', 'second', 'sequence', 'sha1', 'sha2', 'shiftLeft',
+    'shiftRight', 'shiftRightUnsigned', 'shuffle', 'signum', 'sin', 'sinh', 'size', 'skewness',
+    'slice', 'sort_array', 'soundex', 'spark_partition_id', 'split', 'sqrt', 'stddev', 'stddev_pop',
+    'stddev_samp', 'struct', 'substring', 'substring_index', 'sum', 'sumDistinct', 'tan', 'tanh',
+    'to_csv', 'to_date', 'to_json', 'to_timestamp', 'to_utc_timestamp', 'translate', 'trim',
+    'trunc', 'typedLit', 'udf', 'unbase64', 'unhex', 'unix_timestamp', 'upper', 'var_pop',
+    'var_samp', 'variance', 'weekofyear', 'when', 'window', 'xxhash64', 'year'
+]

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -25,7 +25,7 @@ from pysparkling.sql.expressions.mappers import CaseWhen, Rand, CreateStruct, Gr
     Round, Bround, Signum, Sin, Sinh, Tan, Tanh, ToDegrees, ToRadians, Ascii, Base64, ConcatWs, \
     FormatNumber, Length, Lower, RegExpExtract, RegExpReplace, UnBase64, StringSplit, \
     SubstringIndex, Upper, Concat, Reverse, MapKeys, MapValues, MapEntries, MapFromEntries, \
-    MapConcat
+    MapConcat, ShiftLeft, ShiftRight, ShiftRightUnsigned
 from pysparkling.sql.expressions.literals import Literal
 from pysparkling.sql.expressions.operators import IsNull, BitwiseNot, Pow, Substring
 from pysparkling.sql.expressions.strings import InitCap, StringInStr, Levenshtein, StringLocate, \
@@ -1076,21 +1076,21 @@ def shiftLeft(e, numBits):
     """
     :rtype: Column
     """
-    raise NotImplementedError("Pysparkling does not support yet this function")
+    return col(ShiftLeft(parse(e), lit(numBits)))
 
 
 def shiftRight(e, numBits):
     """
     :rtype: Column
     """
-    raise NotImplementedError("Pysparkling does not support yet this function")
+    return col(ShiftRight(parse(e), lit(numBits)))
 
 
 def shiftRightUnsigned(e, numBits):
     """
     :rtype: Column
     """
-    raise NotImplementedError("Pysparkling does not support yet this function")
+    return col(ShiftRightUnsigned(parse(e), lit(numBits)))
 
 
 def signum(e):

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -335,16 +335,19 @@ def struct(*exprs):
     >>> from pysparkling.sql.session import SparkSession
     >>> spark = SparkSession(Context())
     >>> df = spark.createDataFrame([Row(age=2, name='Alice'), Row(age=5, name='Bob')])
-    >>> df.select(struct("age", col("name")).alias("struct")).collect()
+    >>> df.select(struct([df.age, df.name]).alias("struct")).collect()
+    [Row(struct=Row(age=2, name='Alice')), Row(struct=Row(age=5, name='Bob'))]
+    >>> df.select(struct('age', 'name').alias("struct")).collect()
     [Row(struct=Row(age=2, name='Alice')), Row(struct=Row(age=5, name='Bob'))]
     >>> df.select(struct("age", col("name"))).show()
-    +----------------------------------+
-    |named_struct(age, age, name, name)|
-    +----------------------------------+
-    |                        [2, Alice]|
-    |                          [5, Bob]|
-    +----------------------------------+
-
+    +-----------------+
+    |struct(age, name)|
+    +-----------------+
+    |       [2, Alice]|
+    |         [5, Bob]|
+    +-----------------+
+    >>> df.select(struct("age", col("name"))).collect()
+    [Row(struct(age, name)=Row(age=2, name='Alice')), Row(struct(age, name)=Row(age=5, name='Bob'))]
     """
     if len(exprs) == 1 and isinstance(exprs[0], list):
         exprs = exprs[0]

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -346,6 +346,8 @@ def struct(*exprs):
     +----------------------------------+
 
     """
+    if len(exprs) == 1 and isinstance(exprs[0], list):
+        exprs = exprs[0]
     cols = [parse(e) for e in exprs]
     return col(CreateStruct(cols))
 

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -2494,7 +2494,7 @@ __all__ = [
     'locate', 'log', 'log10', 'log1p', 'log2', 'lower', 'lpad', 'ltrim', 'map_concat',
     'map_entries', 'map_from_arrays', 'map_from_entries', 'map_keys', 'map_values', 'math', 'max',
     'md5', 'mean', 'min', 'minute', 'monotonically_increasing_id', 'month', 'months_between',
-    'nanvl', 'next_day', 'ntile', 'pandas_udf', 'parse', 'percent_rank', 'posexplode',
+    'nanvl', 'next_day', 'ntile', 'pandas_udf', 'parse', 'percent_rank', 'pmod', 'posexplode',
     'posexplode_outer', 'pow', 'quarter', 'radians', 'rand', 'randn', 'rank', 'regexp_extract',
     'regexp_replace', 'repeat', 'reverse', 'rint', 'round', 'row_number', 'rpad', 'rtrim',
     'schema_of_csv', 'schema_of_json', 'second', 'sequence', 'sha1', 'sha2', 'shiftLeft',

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -2494,7 +2494,7 @@ __all__ = [
     'locate', 'log', 'log10', 'log1p', 'log2', 'lower', 'lpad', 'ltrim', 'map_concat',
     'map_entries', 'map_from_arrays', 'map_from_entries', 'map_keys', 'map_values', 'math', 'max',
     'md5', 'mean', 'min', 'minute', 'monotonically_increasing_id', 'month', 'months_between',
-    'nanvl', 'next_day', 'ntile', 'pandas_udf', 'parse', 'percent_rank', 'pmod', 'posexplode',
+    'nanvl', 'next_day', 'ntile', 'pandas_udf', 'parse', 'percent_rank', 'posexplode',
     'posexplode_outer', 'pow', 'quarter', 'radians', 'rand', 'randn', 'rank', 'regexp_extract',
     'regexp_replace', 'repeat', 'reverse', 'rint', 'round', 'row_number', 'rpad', 'rtrim',
     'schema_of_csv', 'schema_of_json', 'second', 'sequence', 'sha1', 'sha2', 'shiftLeft',


### PR DESCRIPTION
This PR ensures that all expression parameters are either Column or Expressions.

The main idea behind that change is to be able to easily handle functions once the SQL string is converted in a tree.
In such a tree, e.g. `count(1)`, raw values (here `1`) are literal expression, with an internal value of 1:

```
|SingleExpressionContext
|-NamedExpressionContext
|--ExpressionContext
|---PredicatedContext
|----ValueExpressionDefaultContext
|-----FunctionCallContext           <----- It's a function call
|------FunctionNameContext
|-------QualifiedNameContext
|--------IdentifierContext
|---------UnquotedIdentifierContext
|----------TerminalNodeImpl[count]  <---- function name allow to identify the Count expression
|------TerminalNodeImpl[(]
|------ExpressionContext
|-------PredicatedContext
|--------ValueExpressionDefaultContext
|---------ConstantDefaultContext    <---- This context converts its content to Literal [1]
|----------NumericLiteralContext
|-----------IntegerLiteralContext
|------------TerminalNodeImpl[1]   <---- internal value is an int
|------TerminalNodeImpl[)]
|-TerminalNodeImpl[<EOF>]
 ```

So this tree will be translated in `Count(Literal(1))`, hence we need Count (and other expressions) to expect Literal as parameters.

[1]: We convert constant to Literals because we want 3 + 3 to be considered as the addition of 2 literals (and not as 6):
> df.selectExpr("3+3")
DataFrame[(**3 + 3**): int]


The PR also contains minor fixes related to some expression implementations.