### PR TITLE
Feat/expression registry

### DIFF
--- a/pysparkling/sql/expressions/aggregate/aggregations.py
+++ b/pysparkling/sql/expressions/aggregate/aggregations.py
@@ -15,5 +15,5 @@ class Aggregation(Expression):
     def eval(self, row, schema):
         raise NotImplementedError
 
-    def __str__(self):
+    def args(self):
         raise NotImplementedError

--- a/pysparkling/sql/expressions/aggregate/collectors.py
+++ b/pysparkling/sql/expressions/aggregate/collectors.py
@@ -2,6 +2,8 @@ from pysparkling.sql.expressions.aggregate.aggregations import Aggregation
 
 
 class CollectList(Aggregation):
+    pretty_name = "collect_list"
+
     def __init__(self, column):
         super(CollectList, self).__init__(column)
         self.column = column
@@ -16,11 +18,13 @@ class CollectList(Aggregation):
     def eval(self, row, schema):
         return self.items
 
-    def __str__(self):
-        return "collect_list({0})".format(self.column)
+    def args(self):
+        return (self.column,)
 
 
 class CollectSet(Aggregation):
+    pretty_name = "collect_set"
+
     def __init__(self, column):
         super(CollectSet, self).__init__(column)
         self.column = column
@@ -35,11 +39,13 @@ class CollectSet(Aggregation):
     def eval(self, row, schema):
         return list(self.items)
 
-    def __str__(self):
-        return "collect_set({0})".format(self.column)
+    def args(self):
+        return (self.column,)
 
 
 class SumDistinct(Aggregation):
+    pretty_name = "sum_distinct"
+
     def __init__(self, column):
         super(SumDistinct, self).__init__(column)
         self.column = column
@@ -54,11 +60,12 @@ class SumDistinct(Aggregation):
     def eval(self, row, schema):
         return sum(self.items)
 
-    def __str__(self):
-        return "sum_distinct({0})".format(self.column)
+    def args(self):
+        return (self.column,)
 
 
 class First(Aggregation):
+    pretty_name = "first"
     _sentinel = object()
 
     def __init__(self, column, ignore_nulls):
@@ -78,11 +85,15 @@ class First(Aggregation):
     def eval(self, row, schema):
         return self.value if self.value is not First._sentinel else None
 
-    def __str__(self):
-        return "first({0}, {1})".format(self.column, str(self.ignore_nulls).lower())
+    def args(self):
+        return (
+            self.column,
+            str(self.ignore_nulls).lower()
+        )
 
 
 class Last(Aggregation):
+    pretty_name = "last"
     _sentinel = object()
 
     def __init__(self, column, ignore_nulls):
@@ -103,11 +114,16 @@ class Last(Aggregation):
     def eval(self, row, schema):
         return self.value
 
-    def __str__(self):
-        return "last({0}, {1})".format(self.column, str(self.ignore_nulls).lower())
+    def args(self):
+        return (
+            self.column,
+            str(self.ignore_nulls).lower()
+        )
 
 
 class CountDistinct(Aggregation):
+    pretty_name = "count"
+
     def __init__(self, columns):
         super(CountDistinct, self).__init__(columns)
         self.columns = columns
@@ -124,11 +140,13 @@ class CountDistinct(Aggregation):
     def eval(self, row, schema):
         return len(self.items)
 
-    def __str__(self):
-        return "count(DISTINCT {0})".format(",".join(self.columns))
+    def args(self):
+        return "DISTINCT {0}".format(",".join(self.columns))
 
 
 class ApproxCountDistinct(Aggregation):
+    pretty_name = "approx_count_distinct"
+
     def __init__(self, column):
         super(ApproxCountDistinct, self).__init__(column)
         self.column = column
@@ -143,8 +161,8 @@ class ApproxCountDistinct(Aggregation):
     def eval(self, row, schema):
         return len(self.items)
 
-    def __str__(self):
-        return "approx_count_distinct({0})".format(self.column)
+    def args(self):
+        return (self.column,)
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/aggregate/covariance_aggregations.py
+++ b/pysparkling/sql/expressions/aggregate/covariance_aggregations.py
@@ -20,32 +20,32 @@ class CovarianceStatAggregation(Aggregation):
     def eval(self, row, schema):
         raise NotImplementedError
 
-    def __str__(self):
-        raise NotImplementedError
+    def args(self):
+        return (
+            self.column1,
+            self.column2
+        )
 
 
 class Corr(CovarianceStatAggregation):
+    pretty_name = "corr"
+
     def eval(self, row, schema):
         return self.stat_helper.pearson_correlation
 
-    def __str__(self):
-        return "corr({0}, {1})".format(self.column1, self.column2)
-
 
 class CovarSamp(CovarianceStatAggregation):
+    pretty_name = "covar_samp"
+
     def eval(self, row, schema):
         return self.stat_helper.covar_samp
 
-    def __str__(self):
-        return "covar_samp({0}, {1})".format(self.column1, self.column2)
-
 
 class CovarPop(CovarianceStatAggregation):
+    pretty_name = "covar_pop"
+
     def eval(self, row, schema):
         return self.stat_helper.covar_pop
-
-    def __str__(self):
-        return "covar_pop({0}, {1})".format(self.column1, self.column2)
 
 
 __all__ = ["Corr", "CovarSamp", "CovarPop"]

--- a/pysparkling/sql/expressions/aggregate/stat_aggregations.py
+++ b/pysparkling/sql/expressions/aggregate/stat_aggregations.py
@@ -22,11 +22,13 @@ class SimpleStatAggregation(Aggregation):
     def eval(self, row, schema):
         raise NotImplementedError
 
-    def __str__(self):
-        raise NotImplementedError
+    def args(self):
+        return (self.column,)
 
 
 class Count(SimpleStatAggregation):
+    pretty_name = "count"
+
     def __init__(self, column):
         # Top level import would cause cyclic dependencies
         # pylint: disable=import-outside-toplevel
@@ -40,88 +42,75 @@ class Count(SimpleStatAggregation):
     def eval(self, row, schema):
         return self.stat_helper.count
 
-    def __str__(self):
-        return "count({0})".format(self.column)
-
 
 class Max(SimpleStatAggregation):
+    pretty_name = "max"
+
     def eval(self, row, schema):
         return self.stat_helper.max
 
-    def __str__(self):
-        return "max({0})".format(self.column)
-
 
 class Min(SimpleStatAggregation):
+    pretty_name = "min"
+
     def eval(self, row, schema):
         return self.stat_helper.min
 
-    def __str__(self):
-        return "min({0})".format(self.column)
-
 
 class Sum(SimpleStatAggregation):
+    pretty_name = "sum"
+
     def eval(self, row, schema):
         return self.stat_helper.sum
 
-    def __str__(self):
-        return "sum({0})".format(self.column)
-
 
 class Avg(SimpleStatAggregation):
+    pretty_name = "avg"
+
     def eval(self, row, schema):
         return self.stat_helper.mean
 
-    def __str__(self):
-        return "avg({0})".format(self.column)
-
 
 class VarSamp(SimpleStatAggregation):
+    pretty_name = "var_samp"
+
     def eval(self, row, schema):
         return self.stat_helper.variance_samp
 
-    def __str__(self):
-        return "var_samp({0})".format(self.column)
-
 
 class VarPop(SimpleStatAggregation):
+    pretty_name = "var_pop"
+
     def eval(self, row, schema):
         return self.stat_helper.variance_pop
 
-    def __str__(self):
-        return "var_pop({0})".format(self.column)
-
 
 class StddevSamp(SimpleStatAggregation):
+    pretty_name = "stddev_samp"
+
     def eval(self, row, schema):
         return self.stat_helper.stddev_samp
 
-    def __str__(self):
-        return "stddev_samp({0})".format(self.column)
-
 
 class StddevPop(SimpleStatAggregation):
+    pretty_name = "stddev_pop"
+
     def eval(self, row, schema):
         return self.stat_helper.stddev_pop
 
-    def __str__(self):
-        return "stddev_pop({0})".format(self.column)
-
 
 class Skewness(SimpleStatAggregation):
+    pretty_name = "skewness"
+
     def eval(self, row, schema):
         return self.stat_helper.skewness
 
-    def __str__(self):
-        return "skewness({0})".format(self.column)
-
 
 class Kurtosis(SimpleStatAggregation):
+    pretty_name = "kurtosis"
+
     def eval(self, row, schema):
         return self.stat_helper.kurtosis
-
-    def __str__(self):
-        return "kurtosis({0})".format(self.column)
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/arrays.py
+++ b/pysparkling/sql/expressions/arrays.py
@@ -1,16 +1,13 @@
-from pysparkling.sql.expressions.expressions import Expression, UnaryExpression
+from pysparkling.sql.expressions.expressions import Expression, UnaryExpression, BinaryOperation
 from pysparkling.sql.utils import AnalysisException
 
 
-class ArraysOverlap(Expression):
-    def __init__(self, array1, array2):
-        super(ArraysOverlap, self).__init__(array1, array2)
-        self.array1 = array1
-        self.array2 = array2
+class ArraysOverlap(BinaryOperation):
+    pretty_name = "array_overlap"
 
     def eval(self, row, schema):
-        set1 = set(self.array1.eval(row, schema))
-        set2 = set(self.array2.eval(row, schema))
+        set1 = set(self.arg1.eval(row, schema))
+        set2 = set(self.arg2.eval(row, schema))
         overlap = set1 & set2
         if len(overlap) > 1 or (len(overlap) == 1 and None not in overlap):
             return True
@@ -18,11 +15,10 @@ class ArraysOverlap(Expression):
             return None
         return False
 
-    def __str__(self):
-        return "array_overlap({0}, {1})".format(self.array1, self.array2)
-
 
 class ArrayContains(Expression):
+    pretty_name = "array_contains"
+
     def __init__(self, array, value):
         self.array = array
         self.value = value.get_literal_value()
@@ -34,11 +30,16 @@ class ArrayContains(Expression):
             return None
         return self.value in array_eval
 
-    def __str__(self):
-        return "array_contains({0}, {1})".format(self.array, self.value)
+    def args(self):
+        return (
+            self.array,
+            self.value
+        )
 
 
 class ArrayColumn(Expression):
+    pretty_name = "array"
+
     def __init__(self, columns):
         super(ArrayColumn, self).__init__(columns)
         self.columns = columns
@@ -46,11 +47,13 @@ class ArrayColumn(Expression):
     def eval(self, row, schema):
         return [col.eval(row, schema) for col in self.columns]
 
-    def __str__(self):
-        return "array({0})".format(", ".join(str(col) for col in self.columns))
+    def args(self):
+        return self.columns
 
 
 class MapColumn(Expression):
+    pretty_name = "map"
+
     def __init__(self, columns):
         super(MapColumn, self).__init__(columns)
         self.columns = columns
@@ -63,11 +66,13 @@ class MapColumn(Expression):
             for key, value in zip(self.keys, self.values)
         )
 
-    def __str__(self):
-        return "map({0})".format(", ".join(str(col) for col in self.columns))
+    def args(self):
+        return self.columns
 
 
 class MapFromArraysColumn(Expression):
+    pretty_name = "map_from_arrays"
+
     def __init__(self, keys, values):
         super(MapFromArraysColumn, self).__init__(keys, values)
         self.keys = keys
@@ -78,14 +83,16 @@ class MapFromArraysColumn(Expression):
             zip(self.keys.eval(row, schema), self.values.eval(row, schema))
         )
 
-    def __str__(self):
-        return "map_from_arrays({0}, {1})".format(
+    def args(self):
+        return (
             self.keys,
             self.values
         )
 
 
 class Size(UnaryExpression):
+    pretty_name = "size"
+
     def eval(self, row, schema):
         column_value = self.column.eval(row, schema)
         if isinstance(column_value, (list, dict)):
@@ -97,35 +104,31 @@ class Size(UnaryExpression):
             )
         )
 
-    def __str__(self):
-        return "size({0})".format(self.column)
-
 
 class ArraySort(UnaryExpression):
+    pretty_name = "array_sort"
+
     def eval(self, row, schema):
         return sorted(self.column.eval(row, schema))
 
-    def __str__(self):
-        return "array_sort({0})".format(self.column)
-
 
 class ArrayMin(UnaryExpression):
+    pretty_name = "array_min"
+
     def eval(self, row, schema):
         return min(self.column.eval(row, schema))
 
-    def __str__(self):
-        return "array_min({0})".format(self.column)
-
 
 class ArrayMax(UnaryExpression):
+    pretty_name = "array_max"
+
     def eval(self, row, schema):
         return max(self.column.eval(row, schema))
 
-    def __str__(self):
-        return "array_max({0})".format(self.column)
-
 
 class Slice(Expression):
+    pretty_name = "slice"
+
     def __init__(self, column, start, length):
         self.column = column
         self.start = start.get_literal_value()
@@ -135,11 +138,17 @@ class Slice(Expression):
     def eval(self, row, schema):
         return self.column.eval(row, schema)[self.start, self.start + self.length]
 
-    def __str__(self):
-        return "slice({0}, {1}, {2})".format(self.column, self.start, self.length)
+    def args(self):
+        return (
+            self.column,
+            self.start,
+            self.length
+        )
 
 
 class ArrayRepeat(Expression):
+    pretty_name = "array_repeat"
+
     def __init__(self, col, count):
         super(ArrayRepeat, self).__init__(col)
         self.col = col
@@ -149,11 +158,16 @@ class ArrayRepeat(Expression):
         value = self.col.eval(row, schema)
         return [value for _ in range(self.count)]
 
-    def __str__(self):
-        return "array_repeat({0}, {1})".format(self.col, self.count)
+    def args(self):
+        return (
+            self.col,
+            self.count
+        )
 
 
 class Sequence(Expression):
+    pretty_name = "array_join"
+
     def __init__(self, start, stop, step):
         super(Sequence, self).__init__(start, stop, step)
         self.start = start
@@ -180,17 +194,24 @@ class Sequence(Expression):
 
         return list(range(start_value, stop_value, step_value))
 
-    def __str__(self):
-        return "array_join({0}, {1}{2})".format(
-            self.start,
-            self.stop,
+    def args(self):
+        if self.step is None:
             # Spark use the same logic of not displaying step
             # if it is None, even if it was explicitly set
-            ", {0}".format(self.step) if self.step is not None else ""
+            return (
+                self.start,
+                self.stop
+            )
+        return (
+            self.start,
+            self.stop,
+            self.step
         )
 
 
 class ArrayJoin(Expression):
+    pretty_name = "array_join"
+
     def __init__(self, column, delimiter, nullReplacement):
         super(ArrayJoin, self).__init__(column)
         self.column = column
@@ -203,17 +224,24 @@ class ArrayJoin(Expression):
             value if value is not None else self.nullReplacement for value in column_eval
         )
 
-    def __str__(self):
-        return "array_join({0}, {1}{2})".format(
-            self.column,
-            self.delimiter,
+    def args(self):
+        if self.nullReplacement is None:
             # Spark use the same logic of not displaying nullReplacement
             # if it is None, even if it was explicitly set
-            ", {0}".format(self.nullReplacement) if self.nullReplacement is not None else ""
+            return (
+                self.column,
+                self.delimiter
+            )
+        return (
+            self.column,
+            self.delimiter,
+            self.nullReplacement
         )
 
 
 class SortArray(Expression):
+    pretty_name = "sort_array"
+
     def __init__(self, col, asc):
         super(SortArray, self).__init__(col)
         self.col = col
@@ -222,14 +250,16 @@ class SortArray(Expression):
     def eval(self, row, schema):
         return sorted(self.col.eval(row, schema), reverse=not self.asc)
 
-    def __str__(self):
-        return "sort_array({0}, {1})".format(
+    def args(self):
+        return (
             self.col,
             self.asc
         )
 
 
 class ArraysZip(Expression):
+    pretty_name = "arrays_zip"
+
     def __init__(self, cols):
         super(ArraysZip, self).__init__(*cols)
         self.cols = cols
@@ -242,11 +272,13 @@ class ArraysZip(Expression):
             )
         ]
 
-    def __str__(self):
-        return "arrays_zip({0})".format(", ".join(self.cols))
+    def args(self):
+        return self.cols
 
 
 class Flatten(UnaryExpression):
+    pretty_name = "flatten"
+
     def eval(self, row, schema):
         return [
             value
@@ -254,11 +286,10 @@ class Flatten(UnaryExpression):
             for value in array
         ]
 
-    def __str__(self):
-        return "flatten({0})".format(self.column)
-
 
 class ArrayPosition(Expression):
+    pretty_name = "array_position"
+
     def __init__(self, col, value):
         super(ArrayPosition, self).__init__(col)
         self.col = col
@@ -273,11 +304,16 @@ class ArrayPosition(Expression):
 
         return col_eval.find(self.value) + 1
 
-    def __str__(self):
-        return "array_position({0}, {1})".format(self.col, self.value)
+    def args(self):
+        return (
+            self.col,
+            self.value
+        )
 
 
 class ElementAt(Expression):
+    pretty_name = "element_at"
+
     def __init__(self, col, extraction):
         super(ElementAt, self).__init__(col)
         self.col = col
@@ -289,11 +325,16 @@ class ElementAt(Expression):
             return col_eval[self.extraction - 1]
         return col_eval.get(self.extraction)
 
-    def __str__(self):
-        return "element_at({0}, {1})".format(self.col, self.extraction)
+    def args(self):
+        return (
+            self.col,
+            self.extraction
+        )
 
 
 class ArrayRemove(Expression):
+    pretty_name = "array_remove"
+
     def __init__(self, col, element):
         super(ArrayRemove, self).__init__(col, element)
         self.col = col
@@ -303,55 +344,39 @@ class ArrayRemove(Expression):
         array = self.col.eval(row, schema)
         return [value for value in array if value != self.element]
 
-    def __str__(self):
-        return "array_remove({0}, {1})".format(self.col, self.element)
+    def args(self):
+        return (
+            self.col,
+            self.element
+        )
 
 
 class ArrayDistinct(UnaryExpression):
+    pretty_name = "array_distinct"
+
     def eval(self, row, schema):
         return list(set(self.column.eval(row, schema)))
 
-    def __str__(self):
-        return "array_distinct({0})".format(self.column)
 
-
-class ArrayIntersect(Expression):
-    def __init__(self, col1, col2):
-        super(ArrayIntersect, self).__init__(col1, col2)
-        self.col1 = col1
-        self.col2 = col2
+class ArrayIntersect(BinaryOperation):
+    pretty_name = "array_intersect"
 
     def eval(self, row, schema):
-        return list(set(self.col1.eval(row, schema)) & set(self.col2.eval(row, schema)))
-
-    def __str__(self):
-        return "array_intersect({0}, {1})".format(self.col1, self.col2)
+        return list(set(self.arg1.eval(row, schema)) & set(self.arg2.eval(row, schema)))
 
 
-class ArrayUnion(Expression):
-    def __init__(self, col1, col2):
-        super(ArrayUnion, self).__init__(col1, col2)
-        self.col1 = col1
-        self.col2 = col2
+class ArrayUnion(BinaryOperation):
+    pretty_name = "array_union"
 
     def eval(self, row, schema):
-        return list(set(self.col1.eval(row, schema)) | set(self.col2.eval(row, schema)))
-
-    def __str__(self):
-        return "array_union({0}, {1})".format(self.col1, self.col2)
+        return list(set(self.arg1.eval(row, schema)) | set(self.arg2.eval(row, schema)))
 
 
-class ArrayExcept(Expression):
-    def __init__(self, col1, col2):
-        super(ArrayExcept, self).__init__(col1, col2)
-        self.col1 = col1
-        self.col2 = col2
+class ArrayExcept(BinaryOperation):
+    pretty_name = "array_except"
 
     def eval(self, row, schema):
-        return list(set(self.col1.eval(row, schema)) - set(self.col2.eval(row, schema)))
-
-    def __str__(self):
-        return "array_except({0}, {1})".format(self.col1, self.col2)
+        return list(set(self.arg1.eval(row, schema)) - set(self.arg2.eval(row, schema)))
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/csvs.py
+++ b/pysparkling/sql/expressions/csvs.py
@@ -10,6 +10,8 @@ sql_csv_function_options = dict(
 
 
 class SchemaOfCsv(Expression):
+    pretty_name = "schema_of_csv"
+
     def __init__(self, column, options):
         super(SchemaOfCsv, self).__init__(column)
         self.column = column
@@ -33,5 +35,5 @@ class SchemaOfCsv(Expression):
         schema = guess_schema_from_strings(record_as_row.__fields__, [record_as_row], self.options)
         return schema.simpleString()
 
-    def __str__(self):
-        return "schema_of_csv({0})".format(self.column)
+    def args(self):
+        return (self.column,)

--- a/pysparkling/sql/expressions/dates.py
+++ b/pysparkling/sql/expressions/dates.py
@@ -14,6 +14,8 @@ DAYS_OF_WEEK = ("MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN")
 
 
 class AddMonths(Expression):
+    pretty_name = "add_months"
+
     def __init__(self, start_date, num_months):
         super(AddMonths, self).__init__(start_date)
         self.start_date = start_date
@@ -23,11 +25,16 @@ class AddMonths(Expression):
     def eval(self, row, schema):
         return self.start_date.cast(DateType()).eval(row, schema) + self.timedelta
 
-    def __str__(self):
-        return "add_months({0}, {1})".format(self.start_date, self.num_months)
+    def args(self):
+        return (
+            self.start_date,
+            self.num_months
+        )
 
 
 class DateAdd(Expression):
+    pretty_name = "date_add"
+
     def __init__(self, start_date, num_days):
         super(DateAdd, self).__init__(start_date)
         self.start_date = start_date
@@ -37,11 +44,16 @@ class DateAdd(Expression):
     def eval(self, row, schema):
         return self.start_date.cast(DateType()).eval(row, schema) + self.timedelta
 
-    def __str__(self):
-        return "date_add({0}, {1})".format(self.start_date, self.num_days)
+    def args(self):
+        return (
+            self.start_date,
+            self.num_days
+        )
 
 
 class DateSub(Expression):
+    pretty_name = "date_sub"
+
     def __init__(self, start_date, num_days):
         super(DateSub, self).__init__(start_date)
         self.start_date = start_date
@@ -51,105 +63,99 @@ class DateSub(Expression):
     def eval(self, row, schema):
         return self.start_date.cast(DateType()).eval(row, schema) - self.timedelta
 
-    def __str__(self):
-        return "date_sub({0}, {1})".format(self.start_date, self.num_days)
+    def args(self):
+        return (
+            self.start_date,
+            self.num_days
+        )
 
 
 class Year(UnaryExpression):
+    pretty_name = "year"
+
     def eval(self, row, schema):
         return self.column.cast(DateType()).eval(row, schema).year
 
-    def __str__(self):
-        return "year({0})".format(self.column)
-
 
 class Month(UnaryExpression):
+    pretty_name = "month"
+
     def eval(self, row, schema):
         return self.column.cast(DateType()).eval(row, schema).month
 
-    def __str__(self):
-        return "month({0})".format(self.column)
-
 
 class Quarter(UnaryExpression):
+    pretty_name = "quarter"
+
     def eval(self, row, schema):
         month = self.column.cast(DateType()).eval(row, schema).month
         return 1 + int((month - 1) / 3)
 
-    def __str__(self):
-        return "quarter({0})".format(self.column)
-
 
 class Hour(UnaryExpression):
+    pretty_name = "hour"
+
     def eval(self, row, schema):
         return self.column.cast(TimestampType()).eval(row, schema).hour
 
-    def __str__(self):
-        return "hour({0})".format(self.column)
-
 
 class Minute(UnaryExpression):
+    pretty_name = "minute"
+
     def eval(self, row, schema):
         return self.column.cast(TimestampType()).eval(row, schema).minute
 
-    def __str__(self):
-        return "minute({0})".format(self.column)
-
 
 class Second(UnaryExpression):
+    pretty_name = "second"
+
     def eval(self, row, schema):
         return self.column.cast(TimestampType()).eval(row, schema).second
 
-    def __str__(self):
-        return "second({0})".format(self.column)
-
 
 class DayOfMonth(UnaryExpression):
+    pretty_name = "dayofmonth"
+
     def eval(self, row, schema):
         return self.column.cast(DateType()).eval(row, schema).day
 
-    def __str__(self):
-        return "dayofmonth({0})".format(self.column)
-
 
 class DayOfYear(UnaryExpression):
+    pretty_name = "dayofyear"
+
     def eval(self, row, schema):
         value = self.column.cast(DateType()).eval(row, schema)
         day_from_the_first = value - datetime.date(value.year, 1, 1)
         return 1 + day_from_the_first.days
 
-    def __str__(self):
-        return "dayofyear({0})".format(self.column)
-
 
 class LastDay(UnaryExpression):
+    pretty_name = "last_day"
+
     def eval(self, row, schema):
         value = self.column.cast(DateType()).eval(row, schema)
         first_of_next_month = value + relativedelta(months=1, day=1)
         return first_of_next_month - datetime.timedelta(days=1)
 
-    def __str__(self):
-        return "last_day({0})".format(self.column)
-
 
 class WeekOfYear(UnaryExpression):
+    pretty_name = "weekofyear"
+
     def eval(self, row, schema):
         return self.column.cast(DateType()).eval(row, schema).isocalendar()[1]
 
-    def __str__(self):
-        return "weekofyear({0})".format(self.column)
-
 
 class DayOfWeek(UnaryExpression):
+    pretty_name = "dayofweek"
+
     def eval(self, row, schema):
         date = self.column.cast(DateType()).eval(row, schema)
         return date.isoweekday() + 1 if date.isoweekday() != 7 else 1
 
-    def __str__(self):
-        return "dayofweek({0})".format(self.column)
-
 
 class NextDay(Expression):
+    pretty_name = "next_day"
+
     def __init__(self, column, day_of_week):
         super(NextDay, self).__init__(column)
         self.column = column
@@ -168,11 +174,16 @@ class NextDay(Expression):
             delta += 7
         return value + datetime.timedelta(days=delta)
 
-    def __str__(self):
-        return "next_day({0}, {1})".format(self.column, self.day_of_week)
+    def args(self):
+        return (
+            self.column,
+            self.day_of_week
+        )
 
 
 class MonthsBetween(Expression):
+    pretty_name = "months_between"
+
     def __init__(self, column1, column2, round_off):
         super(MonthsBetween, self).__init__(column1, column2)
         self.column1 = column1
@@ -209,8 +220,8 @@ class MonthsBetween(Expression):
             return float(round(diff, 8))
         return float(diff)
 
-    def __str__(self):
-        return "months_between({0}, {1}, {2})".format(
+    def args(self):
+        return (
             self.column1,
             self.column2,
             str(self.round_off).lower()
@@ -218,6 +229,8 @@ class MonthsBetween(Expression):
 
 
 class DateDiff(Expression):
+    pretty_name = "datediff"
+
     def __init__(self, column1, column2):
         super(DateDiff, self).__init__(column1, column2)
         self.column1 = column1
@@ -233,11 +246,16 @@ class DateDiff(Expression):
 
         return (value_1 - value_2).days
 
-    def __str__(self):
-        return "datediff({0}, {1})".format(self.column1, self.column2)
+    def args(self):
+        return (
+            self.column1,
+            self.column2
+        )
 
 
 class FromUnixTime(Expression):
+    pretty_name = "from_unixtime"
+
     def __init__(self, column, f):
         super(FromUnixTime, self).__init__(column)
         self.column = column
@@ -248,11 +266,16 @@ class FromUnixTime(Expression):
         timestamp = self.column.cast(FloatType()).eval(row, schema)
         return self.formatter(datetime.datetime.fromtimestamp(timestamp))
 
-    def __str__(self):
-        return "from_unixtime({0}, {1})".format(self.column, self.format)
+    def args(self):
+        return (
+            self.column,
+            self.format
+        )
 
 
 class DateFormat(Expression):
+    pretty_name = "date_format"
+
     def __init__(self, column, f):
         super(DateFormat, self).__init__(column)
         self.column = column
@@ -263,11 +286,16 @@ class DateFormat(Expression):
         timestamp = self.column.cast(TimestampType()).eval(row, schema)
         return self.formatter(timestamp)
 
-    def __str__(self):
-        return "date_format({0}, {1})".format(self.column, self.format)
+    def args(self):
+        return (
+            self.column,
+            self.format
+        )
 
 
 class CurrentTimestamp(Expression):
+    pretty_name = "current_timestamp"
+
     def __init__(self):
         super(CurrentTimestamp, self).__init__()
         self.current_timestamp = None
@@ -279,11 +307,13 @@ class CurrentTimestamp(Expression):
         super(CurrentTimestamp, self).initialize(partition_index)
         self.current_timestamp = datetime.datetime.now()
 
-    def __str__(self):
-        return "current_timestamp()"
+    def args(self):
+        return ()
 
 
 class CurrentDate(Expression):
+    pretty_name = "current_date"
+
     def __init__(self):
         super(CurrentDate, self).__init__()
         self.current_timestamp = None
@@ -295,11 +325,13 @@ class CurrentDate(Expression):
         super(CurrentDate, self).initialize(partition_index)
         self.current_timestamp = datetime.datetime.now()
 
-    def __str__(self):
-        return "current_date()"
+    def args(self):
+        return ()
 
 
 class UnixTimestamp(Expression):
+    pretty_name = "unix_timestamp"
+
     def __init__(self, column, f):
         super(UnixTimestamp, self).__init__(column)
         self.column = column
@@ -310,11 +342,16 @@ class UnixTimestamp(Expression):
         datetime_as_string = self.column.eval(row, schema)
         return self.parser(datetime_as_string)
 
-    def __str__(self):
-        return "unix_timestamp({0}, {1})".format(self.column, self.format)
+    def args(self):
+        return (
+            self.column,
+            self.format
+        )
 
 
 class ParseToTimestamp(Expression):
+    pretty_name = "to_timestamp"
+
     def __init__(self, column, f):
         super(ParseToTimestamp, self).__init__(column)
         self.column = column
@@ -325,14 +362,20 @@ class ParseToTimestamp(Expression):
         datetime_as_string = self.column.eval(row, schema)
         return datetime.datetime.fromtimestamp(self.parser(datetime_as_string))
 
-    def __str__(self):
-        return "to_timestamp('{0}'{1})".format(
-            self.column,
-            ", '{0}'".format(self.format) if self.format is not None else ""
+    def args(self):
+        if self.format is None:
+            return (
+                "'{0}'".format(self.column),
+            )
+        return (
+            "'{0}'".format(self.column),
+            "'{0}'".format(self.format)
         )
 
 
 class ParseToDate(Expression):
+    pretty_name = "to_date"
+
     def __init__(self, column, f):
         super(ParseToDate, self).__init__(column)
         self.column = column
@@ -343,14 +386,20 @@ class ParseToDate(Expression):
         datetime_as_string = self.column.eval(row, schema)
         return datetime.date.fromtimestamp(self.parser(datetime_as_string))
 
-    def __str__(self):
-        return "to_date('{0}'{1})".format(
-            self.column,
-            ", '{0}'".format(self.format) if self.format is not None else ""
+    def args(self):
+        if self.format is None:
+            return (
+                "'{0}'".format(self.column),
+            )
+        return (
+            "'{0}'".format(self.column),
+            "'{0}'".format(self.format)
         )
 
 
 class TruncDate(Expression):
+    pretty_name = "trunc"
+
     def __init__(self, column, level):
         super(TruncDate, self).__init__(column)
         self.column = column
@@ -364,11 +413,16 @@ class TruncDate(Expression):
             return datetime.date(value.year, value.month, 1)
         return None
 
-    def __str__(self):
-        return "trunc({0}, {1})".format(self.column, self.level)
+    def args(self):
+        return (
+            self.column,
+            self.level
+        )
 
 
 class TruncTimestamp(Expression):
+    pretty_name = "date_trunc"
+
     def __init__(self, level, column):
         super(TruncTimestamp, self).__init__(column)
         self.level = level.get_literal_value()
@@ -414,11 +468,16 @@ class TruncTimestamp(Expression):
             )
         return None
 
-    def __str__(self):
-        return "date_trunc({0}, {1})".format(self.level, self.column)
+    def args(self):
+        return (
+            self.level,
+            self.column
+        )
 
 
 class FromUTCTimestamp(Expression):
+    pretty_name = "from_utc_timestamp"
+
     def __init__(self, column, tz):
         super(FromUTCTimestamp, self).__init__(column)
         self.column = column
@@ -433,11 +492,16 @@ class FromUTCTimestamp(Expression):
         local_date = gmt_date.astimezone(self.pytz)
         return local_date.replace(tzinfo=None)
 
-    def __str__(self):
-        return "from_utc_timestamp({0}, {1})".format(self.column, self.tz)
+    def args(self):
+        return (
+            self.column,
+            self.tz
+        )
 
 
 class ToUTCTimestamp(Expression):
+    pretty_name = "to_utc_timestamp"
+
     def __init__(self, column, tz):
         super(ToUTCTimestamp, self).__init__(column)
         self.column = column
@@ -452,8 +516,11 @@ class ToUTCTimestamp(Expression):
         gmt_date = local_date.astimezone(GMT_TIMEZONE)
         return gmt_date.replace(tzinfo=None)
 
-    def __str__(self):
-        return "to_utc_timestamp({0}, {1})".format(self.column, self.tz)
+    def args(self):
+        return (
+            self.column,
+            self.tz
+        )
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -3,8 +3,21 @@ from pysparkling.sql.types import StructField, DataType, \
     INTERNAL_TYPE_ORDER, python_to_spark_type
 from pysparkling.sql.utils import AnalysisException
 
+expression_registry = {}
 
-class Expression(object):
+
+class RegisterExpressions(type):
+    pretty_name = None
+
+    def __init__(cls, what, bases, dct):
+        super(RegisterExpressions, cls).__init__(what, bases, dct)
+        if cls.pretty_name is not None:
+            expression_registry[cls.pretty_name] = cls
+
+
+class Expression(object, metaclass=RegisterExpressions):
+    pretty_name = None
+
     def __init__(self, *children):
         self.children = children
         self.pre_evaluation_schema = None

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -13,6 +13,9 @@ class Expression(object):
         raise NotImplementedError
 
     def __str__(self):
+        return "{0}({1})".format(self.pretty_name, ", ".join(str(arg) for arg in self.args()))
+
+    def args(self):
         raise NotImplementedError
 
     def __repr__(self):
@@ -148,13 +151,13 @@ class UnaryExpression(Expression):
     def eval(self, row, schema):
         raise NotImplementedError
 
-    def __str__(self):
-        raise NotImplementedError
+    def args(self):
+        return (self.column,)
 
 
 class BinaryOperation(Expression):
     """
-    Perform a binary operation but return None if any value is None
+    Represent a binary operation between 2 columns
     """
 
     def __init__(self, arg1, arg2):
@@ -165,13 +168,16 @@ class BinaryOperation(Expression):
     def eval(self, row, schema):
         raise NotImplementedError
 
-    def __str__(self):
-        raise NotImplementedError
+    def args(self):
+        return (
+            self.arg1,
+            self.arg2
+        )
 
 
 class TypeSafeBinaryOperation(BinaryOperation):
     """
-    Perform a type and null-safe binary operation using *comparison* type cast rules:
+    Represent a type and null-safe binary operation using *comparison* type cast rules:
 
     It converts values if they are of different types following PySpark rules:
 
@@ -216,7 +222,7 @@ class TypeSafeBinaryOperation(BinaryOperation):
 
 class NullSafeBinaryOperation(BinaryOperation):
     """
-    Perform a null-safe binary operation
+    Represent a null-safe binary operation
 
     It does not converts values if they are of different types:
     lit(datetime.date(2019, 1, 1)) - lit("2019-01-01") raises an error
@@ -257,7 +263,7 @@ class NullSafeColumnOperation(Expression):
         value = self.column.eval(row, schema)
         return self.unsafe_operation(value)
 
-    def __str__(self):
+    def args(self):
         raise NotImplementedError
 
     def unsafe_operation(self, value):

--- a/pysparkling/sql/expressions/fields.py
+++ b/pysparkling/sql/expressions/fields.py
@@ -18,6 +18,9 @@ class FieldAsExpression(Expression):
     def output_fields(self, schema):
         return [self.field]
 
+    def args(self):
+        return (self.field,)
+
 
 def find_position_in_schema(schema, expr):
     if isinstance(expr, str):

--- a/pysparkling/sql/expressions/jsons.py
+++ b/pysparkling/sql/expressions/jsons.py
@@ -6,6 +6,8 @@ from pysparkling.utils import get_json_encoder
 
 
 class StructsToJson(Expression):
+    pretty_name = "structstojson"
+
     default_options = dict(
         dateFormat="yyyy-MM-dd",
         timestampFormat="yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
@@ -28,10 +30,12 @@ class StructsToJson(Expression):
             separators=(',', ':')
         )
 
-    def __str__(self):
-        return "structstojson({0}{1})".format(
+    def args(self):
+        if self.input_options is None:
+            return (self.column, )
+        return (
             self.column,
-            ", {0}".format(self.input_options) if self.input_options is not None else ""
+            self.input_options
         )
 
 

--- a/pysparkling/sql/expressions/literals.py
+++ b/pysparkling/sql/expressions/literals.py
@@ -25,5 +25,8 @@ class Literal(Expression):
                                     "but got {0}: {1}".format(type(self), self))
         return self.value
 
+    def args(self):
+        return (self.value, )
+
 
 __all__ = ["Literal"]

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -12,6 +12,8 @@ from pysparkling.sql.utils import AnalysisException
 from pysparkling.utils import XORShiftRandom, half_up_round, half_even_round, \
     MonotonicallyIncreasingIDGenerator
 
+JVM_MAX_INTEGER_SIZE = 2 ** 63
+
 
 class StarOperator(Expression):
     @property
@@ -636,7 +638,7 @@ class ShiftRight(Expression):
 
 
 class ShiftRightUnsigned(Expression):
-    pretty_name = "shiftright"
+    pretty_name = "shiftrightunsigned"
 
     def __init__(self, arg, num_bits):
         super(ShiftRightUnsigned, self).__init__(arg)
@@ -644,7 +646,8 @@ class ShiftRightUnsigned(Expression):
         self.num_bits = num_bits.get_literal_value()
 
     def eval(self, row, schema):
-        return self.arg.eval(row, schema) >> self.num_bits
+        rightShifted = self.arg.eval(row, schema) >> self.num_bits
+        return rightShifted % JVM_MAX_INTEGER_SIZE
 
     def args(self):
         return (

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -1,7 +1,7 @@
 from pysparkling import Row
 from pysparkling.sql.casts import get_caster
 from pysparkling.sql.expressions.expressions import Expression, UnaryExpression, \
-    NullSafeBinaryOperation, TypeSafeBinaryOperation
+    NullSafeBinaryOperation, TypeSafeBinaryOperation, BinaryOperation
 from pysparkling.sql.types import StructType
 
 
@@ -128,12 +128,7 @@ class Invert(UnaryExpression):
         return "(NOT {0})".format(self.column)
 
 
-class BitwiseOr(Expression):
-    def __init__(self, arg1, arg2):
-        super(BitwiseOr, self).__init__(arg1, arg2)
-        self.arg1 = arg1
-        self.arg2 = arg2
-
+class BitwiseOr(BinaryOperation):
     def eval(self, row, schema):
         return self.arg1.eval(row, schema) | self.arg2.eval(row, schema)
 
@@ -141,12 +136,7 @@ class BitwiseOr(Expression):
         return "({0} | {1})".format(self.arg1, self.arg2)
 
 
-class BitwiseAnd(Expression):
-    def __init__(self, arg1, arg2):
-        super(BitwiseAnd, self).__init__(arg1, arg2)
-        self.arg1 = arg1
-        self.arg2 = arg2
-
+class BitwiseAnd(BinaryOperation):
     def eval(self, row, schema):
         return self.arg1.eval(row, schema) & self.arg2.eval(row, schema)
 
@@ -154,12 +144,7 @@ class BitwiseAnd(Expression):
         return "({0} & {1})".format(self.arg1, self.arg2)
 
 
-class BitwiseXor(Expression):
-    def __init__(self, arg1, arg2):
-        super(BitwiseXor, self).__init__(arg1, arg2)
-        self.arg1 = arg1
-        self.arg2 = arg2
-
+class BitwiseXor(BinaryOperation):
     def eval(self, row, schema):
         return self.arg1.eval(row, schema) ^ self.arg2.eval(row, schema)
 
@@ -175,12 +160,7 @@ class BitwiseNot(UnaryExpression):
         return "~{0}".format(self.column)
 
 
-class EqNullSafe(Expression):
-    def __init__(self, arg1, arg2):
-        super(EqNullSafe, self).__init__(arg1, arg2)
-        self.arg1 = arg1
-        self.arg2 = arg2
-
+class EqNullSafe(BinaryOperation):
     def eval(self, row, schema):
         return self.arg1.eval(row, schema) == self.arg2.eval(row, schema)
 
@@ -215,8 +195,16 @@ class GetField(Expression):
             return "{0}.{1}".format(self.item, self.field)
         return "{0}[{1}]".format(self.item, self.field)
 
+    def args(self):
+        return (
+            self.item,
+            self.field
+        )
+
 
 class Contains(Expression):
+    pretty_name = "contains"
+
     def __init__(self, expr, value):
         super(Contains, self).__init__(expr, value)
         self.expr = expr
@@ -225,11 +213,16 @@ class Contains(Expression):
     def eval(self, row, schema):
         return self.value.eval(row, schema) in self.expr.eval(row, schema)
 
-    def __str__(self):
-        return "contains({0}, {1})".format(self.expr, self.value)
+    def args(self):
+        return (
+            self.expr,
+            self.value
+        )
 
 
 class StartsWith(Expression):
+    pretty_name = "startswith"
+
     def __init__(self, arg1, substr):
         super(StartsWith, self).__init__(arg1, substr)
         self.arg1 = arg1
@@ -238,11 +231,16 @@ class StartsWith(Expression):
     def eval(self, row, schema):
         return str(self.arg1.eval(row, schema)).startswith(self.substr)
 
-    def __str__(self):
-        return "startswith({0}, {1})".format(self.arg1, self.substr)
+    def args(self):
+        return (
+            self.arg1,
+            self.substr
+        )
 
 
 class EndsWith(Expression):
+    pretty_name = "endswith"
+
     def __init__(self, arg1, substr):
         super(EndsWith, self).__init__(arg1, substr)
         self.arg1 = arg1
@@ -251,8 +249,11 @@ class EndsWith(Expression):
     def eval(self, row, schema):
         return str(self.arg1.eval(row, schema)).endswith(self.substr)
 
-    def __str__(self):
-        return "endswith({0}, {1})".format(self.arg1, self.substr)
+    def args(self):
+        return (
+            self.arg1,
+            self.substr
+        )
 
 
 class IsIn(Expression):
@@ -269,6 +270,9 @@ class IsIn(Expression):
             self.arg1,
             ", ".join(str(col) for col in self.cols)
         )
+
+    def args(self):
+        return [self.arg1] + self.cols
 
 
 class IsNotNull(UnaryExpression):
@@ -308,8 +312,16 @@ class Cast(Expression):
             self.destination_type.simpleString().upper()
         )
 
+    def args(self):
+        return (
+            self.column,
+            self.destination_type
+        )
+
 
 class Substring(Expression):
+    pretty_name = "substring"
+
     def __init__(self, expr, start, length):
         super(Substring, self).__init__(expr)
         self.expr = expr
@@ -319,8 +331,12 @@ class Substring(Expression):
     def eval(self, row, schema):
         return str(self.expr.eval(row, schema))[self.start - 1:self.start - 1 + self.length]
 
-    def __str__(self):
-        return "substring({0}, {1}, {2})".format(self.expr, self.start, self.length)
+    def args(self):
+        return (
+            self.expr,
+            self.start,
+            self.length
+        )
 
 
 class Alias(Expression):
@@ -346,6 +362,12 @@ class Alias(Expression):
 
     def __str__(self):
         return self.alias
+
+    def args(self):
+        return (
+            self.expr,
+            self.alias
+        )
 
 
 class UnaryPositive(UnaryExpression):

--- a/pysparkling/sql/expressions/orders.py
+++ b/pysparkling/sql/expressions/orders.py
@@ -14,6 +14,9 @@ class SortOrder(Expression):
     def __str__(self):
         return "{0} {1}".format(self.column, self.sort_order)
 
+    def args(self):
+        return (self.column,)
+
 
 class AscNullsFirst(SortOrder):
     sort_order = "ASC NULLS FIRST"

--- a/pysparkling/sql/expressions/userdefined.py
+++ b/pysparkling/sql/expressions/userdefined.py
@@ -14,8 +14,11 @@ class UserDefinedFunction(Expression):
     def __str__(self):
         return "{0}({1})".format(
             self.f.__name__,
-            ", ".join(str(expr) for expr in self.exprs)
+            ", ".join(str(arg) for arg in self.args())
         )
+
+    def args(self):
+        return self.exprs
 
 
 __all__ = ["UserDefinedFunction"]

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -1080,6 +1080,26 @@ def bround(e, scale=0):
 def shiftLeft(e, numBits):
     """
     :rtype: Column
+
+    >>> from pysparkling import Context
+    >>> from pysparkling.sql.session import SparkSession
+    >>> from pysparkling.sql.functions import shiftLeft, shiftRight, shiftRightUnsigned
+    >>> spark = SparkSession(Context())
+    >>> df = spark.range(-5, 4)
+    >>> df.select("id", shiftLeft("id", 1)).show()
+    +---+----------------+
+    | id|shiftleft(id, 1)|
+    +---+----------------+
+    | -5|             -10|
+    | -4|              -8|
+    | -3|              -6|
+    | -2|              -4|
+    | -1|              -2|
+    |  0|               0|
+    |  1|               2|
+    |  2|               4|
+    |  3|               6|
+    +---+----------------+
     """
     return col(ShiftLeft(parse(e), lit(numBits)))
 
@@ -1087,6 +1107,27 @@ def shiftLeft(e, numBits):
 def shiftRight(e, numBits):
     """
     :rtype: Column
+
+    >>> from pysparkling import Context
+    >>> from pysparkling.sql.session import SparkSession
+    >>> from pysparkling.sql.functions import shiftLeft, shiftRight, shiftRightUnsigned
+    >>> spark = SparkSession(Context())
+    >>> df = spark.range(-5, 4)
+    >>> df.select("id", shiftRight("id", 1)).show()
+    +---+-----------------+
+    | id|shiftright(id, 1)|
+    +---+-----------------+
+    | -5|               -3|
+    | -4|               -2|
+    | -3|               -2|
+    | -2|               -1|
+    | -1|               -1|
+    |  0|                0|
+    |  1|                0|
+    |  2|                1|
+    |  3|                1|
+    +---+-----------------+
+
     """
     return col(ShiftRight(parse(e), lit(numBits)))
 

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -1094,6 +1094,26 @@ def shiftRight(e, numBits):
 def shiftRightUnsigned(e, numBits):
     """
     :rtype: Column
+
+    >>> from pysparkling import Context
+    >>> from pysparkling.sql.session import SparkSession
+    >>> from pysparkling.sql.functions import shiftLeft, shiftRight, shiftRightUnsigned
+    >>> spark = SparkSession(Context())
+    >>> df = spark.range(-5, 4)
+    >>> df.select("id", shiftRight("id", 1), shiftRightUnsigned("id", 1)).show()
+    +---+-----------------+-------------------------+
+    | id|shiftright(id, 1)|shiftrightunsigned(id, 1)|
+    +---+-----------------+-------------------------+
+    | -5|               -3|      9223372036854775805|
+    | -4|               -2|      9223372036854775806|
+    | -3|               -2|      9223372036854775806|
+    | -2|               -1|      9223372036854775807|
+    | -1|               -1|      9223372036854775807|
+    |  0|                0|                        0|
+    |  1|                0|                        0|
+    |  2|                1|                        1|
+    |  3|                1|                        1|
+    +---+-----------------+-------------------------+
     """
     return col(ShiftRightUnsigned(parse(e), lit(numBits)))
 

--- a/pysparkling/sql/internal_utils/writers.py
+++ b/pysparkling/sql/internal_utils/writers.py
@@ -110,6 +110,9 @@ class WriteInFolder(Aggregation):
     def __str__(self):
         return "write_in_folder({0})".format(self.column)
 
+    def args(self):
+        return (self.column,)
+
 
 class DataWriter(object):
     default_options = dict(


### PR DESCRIPTION
This PR is done in the scope of the ongoing implementation of SQL string parsing.

To retrieve an Expression class based on the expression name (e.g. the `Count` Expression in `COUNT(1)`), a mapping needs to be defined.

This PR extracts expression names into a `pretty_name` attribute (names were already defined in `__str__` methods).

Based on that it adds a metaclass to `Expression` to automatically register new expressions when descendant of this class are defined.

Most of the diff comes from Expression's `__str__` now relying on this `pretty_name` variable and the new `Expression.args` method that return an iterable of what should be in the string format `[pretty_name]([arg1], [arg2], [...])`.

PS: Also, going over the code I noticed that ShiftRightUnsigned implementation was only a duplication of ShiftRight's ones so I fixed it.