### PR TITLE
Cleanup with pylint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,12 @@ jobs:
         python -m pip install -e ".[sql]" --use-deprecated=legacy-resolver
 
     - name: Lint
+      if: matrix.python-version == '3.9'
+      # https://github.com/PyCQA/pylint/issues/3882
+      run: pylint pysparkling scripts --disable=fixme,unsubscriptable-object
+
+    - name: Lint
+      if: matrix.python-version != '3.9'
       run: pylint pysparkling scripts --disable=fixme
 
     - name: pycodestyle

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,12 +59,12 @@ jobs:
         python -m pip install -e ".[sql]" --use-deprecated=legacy-resolver
 
     - name: Lint
-      if: matrix.python-version == '3.9'
+      if: matrix.python == '3.9'
       # https://github.com/PyCQA/pylint/issues/3882
       run: pylint pysparkling scripts --disable=fixme,unsubscriptable-object
 
     - name: Lint
-      if: matrix.python-version != '3.9'
+      if: matrix.python != '3.9'
       run: pylint pysparkling scripts --disable=fixme
 
     - name: pycodestyle

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 variable-rgx=[a-z0-9_]{1,30}$
 good-names=log
 
-disable=invalid-name,unused-argument,too-few-public-methods,no-self-use,missing-docstring,logging-format-interpolation,too-many-instance-attributes,duplicate-code,too-many-public-methods,too-many-arguments,protected-access,pointless-string-statement,too-many-lines,useless-object-inheritance,cyclic-import,bad-option-value
+disable=invalid-name,unused-argument,too-few-public-methods,no-self-use,missing-docstring,logging-format-interpolation,too-many-instance-attributes,duplicate-code,too-many-public-methods,too-many-arguments,protected-access,too-many-lines  # ,cyclic-import
 # TODO: cyclic-import is temporary
 
 [FORMAT]

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,8 +3,7 @@
 variable-rgx=[a-z0-9_]{1,30}$
 good-names=log
 
-disable=invalid-name,unused-argument,too-few-public-methods,no-self-use,missing-docstring,logging-format-interpolation,too-many-instance-attributes,duplicate-code,too-many-public-methods,too-many-arguments,protected-access,too-many-lines  # ,cyclic-import
-# TODO: cyclic-import is temporary
+disable=invalid-name,unused-argument,too-few-public-methods,no-self-use,missing-docstring,logging-format-interpolation,too-many-instance-attributes,duplicate-code,too-many-public-methods,too-many-arguments,protected-access,too-many-lines
 
 [FORMAT]
 max-line-length=119

--- a/pysparkling/__init__.py
+++ b/pysparkling/__init__.py
@@ -1,14 +1,8 @@
 """pysparkling module"""
 # flake8: noqa
 
-# isort: off
-from ._version import get_versions
-
-__version__ = get_versions()['version']
-del get_versions
-# isort: on
-
 from . import exceptions, fileio, streaming
+from .__version__ import __version__
 from .accumulators import Accumulator, AccumulatorParam
 from .broadcast import Broadcast
 from .cache_manager import CacheManager, TimedCacheManager

--- a/pysparkling/__init__.py
+++ b/pysparkling/__init__.py
@@ -1,8 +1,14 @@
 """pysparkling module"""
 # flake8: noqa
 
+# isort: off
+from ._version import get_versions
+
+__version__ = get_versions()['version']
+del get_versions
+# isort: on
+
 from . import exceptions, fileio, streaming
-from .__version__ import __version__
 from .accumulators import Accumulator, AccumulatorParam
 from .broadcast import Broadcast
 from .cache_manager import CacheManager, TimedCacheManager

--- a/pysparkling/__init__.py
+++ b/pysparkling/__init__.py
@@ -1,15 +1,11 @@
 """pysparkling module"""
 
-from ._version import get_versions
-
-__version__ = get_versions()['version']
-del get_versions
-
 # isort: off
 from .sql.types import Row
 # isort: on
 
 from . import exceptions, fileio, streaming
+from .__version__ import __version__
 from .accumulators import Accumulator, AccumulatorParam
 from .broadcast import Broadcast
 from .cache_manager import CacheManager, TimedCacheManager

--- a/pysparkling/__init__.py
+++ b/pysparkling/__init__.py
@@ -1,10 +1,6 @@
 """pysparkling module"""
 # flake8: noqa
 
-# isort: off
-from .sql.types import Row
-# isort: on
-
 from . import exceptions, fileio, streaming
 from .__version__ import __version__
 from .accumulators import Accumulator, AccumulatorParam
@@ -12,6 +8,7 @@ from .broadcast import Broadcast
 from .cache_manager import CacheManager, TimedCacheManager
 from .context import Context
 from .rdd import RDD
+from .sql.types import Row
 from .stat_counter import StatCounter
 from .storagelevel import StorageLevel
 

--- a/pysparkling/__init__.py
+++ b/pysparkling/__init__.py
@@ -1,4 +1,5 @@
 """pysparkling module"""
+# flake8: noqa
 
 # isort: off
 from .sql.types import Row

--- a/pysparkling/__version__.py
+++ b/pysparkling/__version__.py
@@ -1,0 +1,3 @@
+from ._version import get_versions
+
+__version__ = get_versions()['version']

--- a/pysparkling/__version__.py
+++ b/pysparkling/__version__.py
@@ -1,3 +1,0 @@
-from ._version import get_versions
-
-__version__ = get_versions()['version']

--- a/pysparkling/accumulators.py
+++ b/pysparkling/accumulators.py
@@ -79,7 +79,7 @@ TypeError: No default accumulator param for type <type 'list'>
 __all__ = ['Accumulator', 'AccumulatorParam']
 
 
-class Accumulator(object):
+class Accumulator:
     """
     A shared variable that can be accumulated, i.e., has a commutative and associative "add"
     operation. Tasks can add values to an Accumulator with the ``+=`` operator
@@ -118,7 +118,7 @@ class Accumulator(object):
         return "Accumulator<value={0}>".format(self._value)
 
 
-class AccumulatorParam(object):
+class AccumulatorParam:
     """
     Helper object that defines how to accumulate values of a given type.
     """

--- a/pysparkling/accumulators.py
+++ b/pysparkling/accumulators.py
@@ -161,11 +161,11 @@ COMPLEX_ACCUMULATOR_PARAM = AddingAccumulatorParam(0.0j)
 
 
 if __name__ == "__main__":
-    """
-    Execute doctests with
-
-    $ python -m pysparkling.accumulators -v
-    """
+    #
+    # Execute doctests with
+    #
+    # $ python -m pysparkling.accumulators -v
+    #
     import doctest
     import sys
 

--- a/pysparkling/broadcast.py
+++ b/pysparkling/broadcast.py
@@ -20,7 +20,7 @@
 __all__ = ['Broadcast']
 
 
-class Broadcast(object):
+class Broadcast:
     """
     A broadcast variable created with ``b = sc.broadcast(0)``.
     Access its value through ``b.value``.

--- a/pysparkling/broadcast.py
+++ b/pysparkling/broadcast.py
@@ -49,11 +49,11 @@ class Broadcast:
 
 
 if __name__ == "__main__":
-    """
-    Execute doctests with
-
-    $ python -m pysparkling.broadcast -v
-    """
+    #
+    # Execute doctests with
+    #
+    # $ python -m pysparkling.accumulators -v
+    #
     import doctest
     import sys
 

--- a/pysparkling/cache_manager.py
+++ b/pysparkling/cache_manager.py
@@ -10,7 +10,7 @@ import zlib
 log = logging.getLogger(__name__)
 
 
-class CacheManager(object):
+class CacheManager:
     """cache manager
 
     When mem_obj or disk_location are None, it means the object does not

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -7,8 +7,8 @@ import struct
 import time
 import traceback
 
-from . import __version__ as PYSPARKLING_VERSION
 from . import accumulators
+from .__version__ import __version__ as PYSPARKLING_VERSION
 from .broadcast import Broadcast
 from .cache_manager import CacheManager
 from .exceptions import ContextIsLockedException

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -7,7 +7,7 @@ import struct
 import time
 import traceback
 
-from . import __version__ as PYSPARKLING_VERSION
+from .__version__ import __version__ as PYSPARKLING_VERSION
 from . import accumulators
 from .broadcast import Broadcast
 from .cache_manager import CacheManager

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -14,7 +14,7 @@ from .cache_manager import CacheManager
 from .exceptions import ContextIsLockedException
 from .fileio import File, TextFile
 from .partition import Partition
-from .rdd import RDD
+from .rdd import EmptyRDD, RDD
 from .task_context import TaskContext
 
 log = logging.getLogger(__name__)
@@ -525,9 +525,6 @@ class Context:
         :param rdds: Iterable of RDDs.
         :rtype: RDD
         """
-        # pylint: disable=import-outside-toplevel, cyclic-import
-        from .rdd import EmptyRDD
-
         if all(isinstance(rdd, EmptyRDD) for rdd in rdds):
             return EmptyRDD(self)
 

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -14,6 +14,7 @@ from .cache_manager import CacheManager
 from .exceptions import ContextIsLockedException
 from .fileio import File, TextFile
 from .partition import Partition
+from .rdd import RDD
 from .task_context import TaskContext
 
 log = logging.getLogger(__name__)
@@ -193,9 +194,6 @@ class Context:
         :rtype: RDD
         """
         if numSlices is None or numSlices <= 1:
-            # pylint: disable=import-outside-toplevel, cyclic-import
-            from .rdd import RDD
-
             return RDD([Partition(x, 0)], self)
 
         x_len_iter, x = itertools.tee(x, 2)
@@ -217,9 +215,6 @@ class Context:
         :param partitions: An iterable over the partitioned data.
         :rtype: RDD
         """
-        # pylint: disable=import-outside-toplevel, cyclic-import
-        from .rdd import RDD
-
         return RDD(
             (Partition(p_data, i) for i, p_data in enumerate(partitions)),
             self,

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -7,8 +7,8 @@ import struct
 import time
 import traceback
 
+from . import __version__ as PYSPARKLING_VERSION
 from . import accumulators
-from .__version__ import __version__ as PYSPARKLING_VERSION
 from .broadcast import Broadcast
 from .cache_manager import CacheManager
 from .exceptions import ContextIsLockedException

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -14,7 +14,6 @@ from .cache_manager import CacheManager
 from .exceptions import ContextIsLockedException
 from .fileio import File, TextFile
 from .partition import Partition
-from .rdd import EmptyRDD, RDD
 from .task_context import TaskContext
 
 log = logging.getLogger(__name__)
@@ -194,6 +193,9 @@ class Context:
         :rtype: RDD
         """
         if numSlices is None or numSlices <= 1:
+            # pylint: disable=import-outside-toplevel, cyclic-import
+            from .rdd import RDD
+
             return RDD([Partition(x, 0)], self)
 
         x_len_iter, x = itertools.tee(x, 2)
@@ -215,6 +217,8 @@ class Context:
         :param partitions: An iterable over the partitioned data.
         :rtype: RDD
         """
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from .rdd import RDD
 
         return RDD(
             (Partition(p_data, i) for i, p_data in enumerate(partitions)),
@@ -526,6 +530,9 @@ class Context:
         :param rdds: Iterable of RDDs.
         :rtype: RDD
         """
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from .rdd import EmptyRDD
+
         if all(isinstance(rdd, EmptyRDD) for rdd in rdds):
             return EmptyRDD(self)
 

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -7,8 +7,8 @@ import struct
 import time
 import traceback
 
-from .__version__ import __version__ as PYSPARKLING_VERSION
 from . import accumulators
+from .__version__ import __version__ as PYSPARKLING_VERSION
 from .broadcast import Broadcast
 from .cache_manager import CacheManager
 from .exceptions import ContextIsLockedException

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -95,7 +95,7 @@ def runJob_map(i):  # pylint: disable=too-many-locals
     ))
 
 
-class Context(object):
+class Context:
     """Context object similar to a Spark Context.
 
     The variable `_stats` contains measured timing information about data and
@@ -571,7 +571,7 @@ class Context(object):
         return rdd
 
 
-class DummyPool(object):
+class DummyPool:
     def __init__(self):
         pass
 
@@ -595,7 +595,7 @@ def map_whole_text_file(f_name__encoding):
     )
 
 
-class FixedLengthChunker(object):
+class FixedLengthChunker:
     def __init__(self, recordLength):
         self.record_length = recordLength
 
@@ -604,7 +604,7 @@ class FixedLengthChunker(object):
             yield data[i: i + self.record_length]
 
 
-class VariableLengthChunker(object):
+class VariableLengthChunker:
     def __init__(self, recordLength):
         self.length_fmt = recordLength
         self.prefix_length = struct.calcsize(recordLength)

--- a/pysparkling/context.py
+++ b/pysparkling/context.py
@@ -14,7 +14,7 @@ from .cache_manager import CacheManager
 from .exceptions import ContextIsLockedException
 from .fileio import File, TextFile
 from .partition import Partition
-from .rdd import EmptyRDD, RDD
+from .rdd import RDD
 from .task_context import TaskContext
 
 log = logging.getLogger(__name__)
@@ -525,6 +525,9 @@ class Context:
         :param rdds: Iterable of RDDs.
         :rtype: RDD
         """
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from .rdd import EmptyRDD
+
         if all(isinstance(rdd, EmptyRDD) for rdd in rdds):
             return EmptyRDD(self)
 

--- a/pysparkling/fileio/codec/codec.py
+++ b/pysparkling/fileio/codec/codec.py
@@ -3,7 +3,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class Codec(object):
+class Codec:
     """Codec."""
     def __init__(self):
         pass

--- a/pysparkling/fileio/file.py
+++ b/pysparkling/fileio/file.py
@@ -8,7 +8,7 @@ from . import codec, fs
 log = logging.getLogger(__name__)
 
 
-class File(object):
+class File:
     """File object.
 
     :param file_name: Any file name.

--- a/pysparkling/fileio/fs/file_system.py
+++ b/pysparkling/fileio/fs/file_system.py
@@ -3,7 +3,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class FileSystem(object):
+class FileSystem:
     """Interface class for the file system.
 
     :param str file_name: File name.

--- a/pysparkling/fileio/fs/gs.py
+++ b/pysparkling/fileio/fs/gs.py
@@ -41,13 +41,13 @@ class GS(FileSystem):
 
         # obtain key
         t = Tokenizer(self.file_name)
-        t.next('://')  # skip scheme
-        bucket_name = t.next('/')
+        t.get_next('://')  # skip scheme
+        bucket_name = t.get_next('/')
         if ':' in bucket_name:
             project_name, _, bucket_name = bucket_name.partition(':')
         else:
             project_name = GS.project_name
-        blob_name = t.next()
+        blob_name = t.get_next()
 
         client = GS._get_client(project_name)
         bucket = client.get_bucket(bucket_name)
@@ -70,13 +70,13 @@ class GS(FileSystem):
         files = []
 
         t = Tokenizer(expr)
-        scheme = t.next('://')
-        bucket_name = t.next('/')
+        scheme = t.get_next('://')
+        bucket_name = t.get_next('/')
         if ':' in bucket_name:
             project_name, _, bucket_name = bucket_name.partition(':')
         else:
             project_name = GS.project_name
-        prefix = t.next(['*', '?'])
+        prefix = t.get_next(['*', '?'])
 
         bucket = GS._get_client(project_name).get_bucket(bucket_name)
         expr_s = len(scheme) + 3 + len(project_name) + 1 + len(bucket_name) + 1
@@ -117,13 +117,13 @@ class GS(FileSystem):
 
     def exists(self):
         t = Tokenizer(self.file_name)
-        t.next('//')  # skip scheme
-        bucket_name = t.next('/')
+        t.get_next('//')  # skip scheme
+        bucket_name = t.get_next('/')
         if ':' in bucket_name:
             project_name, _, bucket_name = bucket_name.partition(':')
         else:
             project_name = GS.project_name
-        blob_name = t.next()
+        blob_name = t.get_next()
         bucket = GS._get_client(project_name).get_bucket(bucket_name)
         return (bucket.get_blob(blob_name)
                 or list(bucket.list_blobs(prefix='{}/'.format(blob_name))))

--- a/pysparkling/fileio/fs/gs.py
+++ b/pysparkling/fileio/fs/gs.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 try:
     from gcloud import storage
-except ImportError as e:
+except ImportError:
     storage = None
 
 

--- a/pysparkling/fileio/fs/local.py
+++ b/pysparkling/fileio/fs/local.py
@@ -25,7 +25,7 @@ class Local(FileSystem):
             expr = '.' + os.path.sep + expr
 
         t = Tokenizer(expr)
-        prefix = t.next(['*', '?'])
+        prefix = t.get_next(['*', '?'])
         if not prefix.endswith('/') and '/' in prefix:
             prefix = os.path.dirname(prefix)
         files = []

--- a/pysparkling/fileio/fs/s3.py
+++ b/pysparkling/fileio/fs/s3.py
@@ -38,9 +38,9 @@ class S3(FileSystem):
 
         # obtain key
         t = Tokenizer(self.file_name)
-        t.next('://')  # skip scheme
-        bucket_name = t.next('/')
-        key_name = t.next()
+        t.get_next('://')  # skip scheme
+        bucket_name = t.get_next('/')
+        key_name = t.get_next()
         conn = self._get_conn()
         bucket = conn.get_bucket(bucket_name, validate=False)
         self.key = bucket.get_key(key_name)
@@ -60,9 +60,9 @@ class S3(FileSystem):
         files = []
 
         t = Tokenizer(expr)
-        scheme = t.next('://')
-        bucket_name = t.next('/')
-        prefix = t.next(['*', '?'])
+        scheme = t.get_next('://')
+        bucket_name = t.get_next('/')
+        prefix = t.get_next(['*', '?'])
 
         bucket = cls._get_conn().get_bucket(
             bucket_name,
@@ -104,9 +104,9 @@ class S3(FileSystem):
 
     def exists(self):
         t = Tokenizer(self.file_name)
-        t.next('//')  # skip scheme
-        bucket_name = t.next('/')
-        key_name = t.next()
+        t.get_next('//')  # skip scheme
+        bucket_name = t.get_next('/')
+        key_name = t.get_next()
         conn = self._get_conn()
         bucket = conn.get_bucket(bucket_name, validate=False)
         return (bucket.get_key(key_name)

--- a/pysparkling/partition.py
+++ b/pysparkling/partition.py
@@ -5,7 +5,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class Partition(object):
+class Partition:
     def __init__(self, x, idx=None):
         self.index = idx
         self._x = list(x)

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -1186,7 +1186,7 @@ class RDD:
                 if lb <= r < ub:
                     lists[i].append(e)
 
-        return [self.context.parallelize(lst) for lst in lists]
+        return [self.context.parallelize(l) for l in lists]
 
     def reduce(self, f):
         """reduce
@@ -2198,13 +2198,13 @@ def unit_map(task_context, elements):
     return list(elements)
 
 
-def unit_collect(lst):
-    return [x for p in lst for x in p]
+def unit_collect(l):
+    return [x for p in l for x in p]
 
 
 def sum_counts_by_keys(list_of_pairlists):
     r = defaultdict(int)  # calling int results in a zero
-    for pair_lst in list_of_pairlists:
-        for key, count in pair_lst.items():
+    for l in list_of_pairlists:
+        for key, count in l.items():
             r[key] += count
     return r

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -20,6 +20,7 @@ except ImportError:
     numpy = None
 
 from . import fileio
+from .context import Context
 from .exceptions import ContextIsLockedException, FileAlreadyExistsException
 from .samplers import BernoulliSampler, BernoulliSamplerPerKey, PoissonSampler, PoissonSamplerPerKey
 from .stat_counter import StatCounter
@@ -2079,10 +2080,7 @@ class RDD:
         >>> rdd.toDF().collect()
         [Row(age=1, name='Alice')]
         """
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling import Context
-        from pysparkling.sql.session import SparkSession
+        from .sql.session import SparkSession
         sparkSession = SparkSession._instantiatedSession or SparkSession(Context())
         return sparkSession.createDataFrame(self, schema, sampleRatio)
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -167,9 +167,9 @@ class RDD:
                 r[k] = seqFunc(r[k], v)
             return r
 
-        def combFuncByKey(lst):
+        def combFuncByKey(l):
             r = defaultdict(lambda: copy.deepcopy(zeroValue))
-            for p in lst:
+            for p in l:
                 for k, v in p.items():
                     r[k] = combFunc(r[k], v)
             return r

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -37,7 +37,7 @@ def _hash(v):
     return portable_hash(v) & 0xffffffff
 
 
-class RDD(object):
+class RDD:
     """RDD
 
     In Spark's original form, RDDs are Resilient, Distributed Datasets.
@@ -2190,7 +2190,7 @@ class EmptyRDD(RDD):
 
 # pickle-able helpers
 
-class MapF(object):
+class MapF:
     def __init__(self, f):
         self.f = f
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -42,7 +42,7 @@ class RDD:
     This class reimplements the same interface with the goal of being
     fast on small data at the cost of being resilient and distributed.
 
-    :param list partitions:
+    :param Iterable partitions:
         A list of instances of :class:`Partition`.
 
     :param Context ctx:
@@ -2080,7 +2080,9 @@ class RDD:
         >>> rdd.toDF().collect()
         [Row(age=1, name='Alice')]
         """
+        # pylint: disable=import-outside-toplevel  # against a cyclic-import
         from .sql.session import SparkSession
+
         sparkSession = SparkSession._instantiatedSession or SparkSession(Context())
         return sparkSession.createDataFrame(self, schema, sampleRatio)
 

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -75,11 +75,10 @@ class RDD:
     def partitions(self):
         return self._p
 
-    """
-
-    Public API
-    ----------
-    """
+    #
+    # Public API
+    # ----------
+    #
 
     def aggregate(self, zeroValue, seqOp, combOp):
         """aggregate

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -167,9 +167,9 @@ class RDD:
                 r[k] = seqFunc(r[k], v)
             return r
 
-        def combFuncByKey(l):
+        def combFuncByKey(lst):
             r = defaultdict(lambda: copy.deepcopy(zeroValue))
-            for p in l:
+            for p in lst:
                 for k, v in p.items():
                     r[k] = combFunc(r[k], v)
             return r
@@ -1186,7 +1186,7 @@ class RDD:
                 if lb <= r < ub:
                     lists[i].append(e)
 
-        return [self.context.parallelize(l) for l in lists]
+        return [self.context.parallelize(lst) for lst in lists]
 
     def reduce(self, f):
         """reduce
@@ -2198,13 +2198,13 @@ def unit_map(task_context, elements):
     return list(elements)
 
 
-def unit_collect(l):
-    return [x for p in l for x in p]
+def unit_collect(lst):
+    return [x for p in lst for x in p]
 
 
 def sum_counts_by_keys(list_of_pairlists):
     r = defaultdict(int)  # calling int results in a zero
-    for l in list_of_pairlists:
-        for key, count in l.items():
+    for pair_lst in list_of_pairlists:
+        for key, count in pair_lst.items():
             r[key] += count
     return r

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -2079,7 +2079,7 @@ class RDD:
         >>> rdd.toDF().collect()
         [Row(age=1, name='Alice')]
         """
-        # pylint: disable=import-outside-toplevel  # against a cyclic-import
+        # pylint: disable=import-outside-toplevel, cyclic-import
         from .sql.session import SparkSession
 
         sparkSession = SparkSession._instantiatedSession or SparkSession(self.context)

--- a/pysparkling/rdd.py
+++ b/pysparkling/rdd.py
@@ -20,7 +20,6 @@ except ImportError:
     numpy = None
 
 from . import fileio
-from .context import Context
 from .exceptions import ContextIsLockedException, FileAlreadyExistsException
 from .samplers import BernoulliSampler, BernoulliSamplerPerKey, PoissonSampler, PoissonSamplerPerKey
 from .stat_counter import StatCounter
@@ -2083,7 +2082,7 @@ class RDD:
         # pylint: disable=import-outside-toplevel  # against a cyclic-import
         from .sql.session import SparkSession
 
-        sparkSession = SparkSession._instantiatedSession or SparkSession(Context())
+        sparkSession = SparkSession._instantiatedSession or SparkSession(self.context)
         return sparkSession.createDataFrame(self, schema, sampleRatio)
 
 

--- a/pysparkling/samplers.py
+++ b/pysparkling/samplers.py
@@ -28,7 +28,7 @@ def poisson(lambda_):
     return pysparkling_poisson(lambda_)
 
 
-class BernoulliSampler(object):
+class BernoulliSampler:
     def __init__(self, expectation):
         self.expectation = expectation
 
@@ -36,7 +36,7 @@ class BernoulliSampler(object):
         return 1 if random.random() < self.expectation else 0
 
 
-class PoissonSampler(object):
+class PoissonSampler:
     def __init__(self, expectation):
         self.expectation = expectation
 
@@ -44,7 +44,7 @@ class PoissonSampler(object):
         return poisson(self.expectation)
 
 
-class BernoulliSamplerPerKey(object):
+class BernoulliSamplerPerKey:
     def __init__(self, expectations):
         self.expectations = expectations
 
@@ -53,7 +53,7 @@ class BernoulliSamplerPerKey(object):
         return 1 if random.random() < self.expectations.get(key, 0.0) else 0
 
 
-class PoissonSamplerPerKey(object):
+class PoissonSamplerPerKey:
     def __init__(self, expectations):
         self.expectations = expectations
 

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -6,12 +6,12 @@ import time
 from dateutil.tz import tzlocal
 import pytz
 
-from pysparkling.sql.types import (
+from .types import (
     ArrayType, BinaryType, BooleanType, ByteType, create_row, DateType, DecimalType, DoubleType, FloatType,
     IntegerType, LongType, MapType, NullType, NumericType, ShortType, StringType, StructType, TimestampType,
     UserDefinedType
 )
-from pysparkling.sql.utils import AnalysisException
+from .utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()
 

--- a/pysparkling/sql/column.py
+++ b/pysparkling/sql/column.py
@@ -530,14 +530,14 @@ class Column:
         :param condition: a boolean :class:`Column` expression.
         :param value: a literal value, or a :class:`Column` expression.
 
-        >>> from pysparkling.sql import functions as F
+        >>> from pysparkling.sql import functions
         >>> from pysparkling import Context, Row
         >>> from pysparkling.sql.session import SparkSession
         >>> spark = SparkSession(Context())
         >>> df = spark.createDataFrame(
         ...   [Row(age=2, name='Alice'), Row(age=5, name='Bob')]
         ... )
-        >>> df.select(df.name, F.when(df.age > 4, 1).when(df.age < 3, -1).otherwise(0)).show()
+        >>> df.select(df.name, functions.when(df.age > 4, 1).when(df.age < 3, -1).otherwise(0)).show()
         +-----+------------------------------------------------------------+
         | name|CASE WHEN (age > 4) THEN 1 WHEN (age < 3) THEN -1 ELSE 0 END|
         +-----+------------------------------------------------------------+
@@ -564,14 +564,14 @@ class Column:
 
         :param value: a literal value, or a :class:`Column` expression.
 
-        >>> from pysparkling.sql import functions as F
+        >>> from pysparkling.sql import functions
         >>> from pysparkling import Context, Row
         >>> from pysparkling.sql.session import SparkSession
         >>> spark = SparkSession(Context())
         >>> df = spark.createDataFrame(
         ...   [Row(age=2, name='Alice'), Row(age=5, name='Bob')]
         ... )
-        >>> df.select(df.name, F.when(df.age > 3, 1).otherwise(0)).show()
+        >>> df.select(df.name, functions.when(df.age > 3, 1).otherwise(0)).show()
         +-----+-------------------------------------+
         | name|CASE WHEN (age > 3) THEN 1 ELSE 0 END|
         +-----+-------------------------------------+

--- a/pysparkling/sql/column.py
+++ b/pysparkling/sql/column.py
@@ -1,17 +1,15 @@
-from pysparkling.sql.expressions.expressions import Expression
-from pysparkling.sql.expressions.fields import find_position_in_schema
-from pysparkling.sql.expressions.literals import Literal
-from pysparkling.sql.expressions.mappers import CaseWhen, StarOperator
-from pysparkling.sql.expressions.operators import (
+from .expressions.expressions import Expression
+from .expressions.fields import find_position_in_schema
+from .expressions.literals import Literal
+from .expressions.mappers import CaseWhen, StarOperator
+from .expressions.operators import (
     Add, Alias, And, BitwiseAnd, BitwiseOr, BitwiseXor, Cast, Contains, Divide, EndsWith, EqNullSafe, Equal, GetField,
     GreaterThan, GreaterThanOrEqual, Invert, IsIn, IsNotNull, IsNull, LessThan, LessThanOrEqual, Minus, Mod, Negate,
     Or, Pow, StartsWith, Substring, Time
 )
-from pysparkling.sql.expressions.orders import (
-    Asc, AscNullsFirst, AscNullsLast, Desc, DescNullsFirst, DescNullsLast, SortOrder
-)
-from pysparkling.sql.types import DataType, string_to_type, StructField
-from pysparkling.sql.utils import AnalysisException, IllegalArgumentException
+from .expressions.orders import Asc, AscNullsFirst, AscNullsLast, Desc, DescNullsFirst, DescNullsLast, SortOrder
+from .types import DataType, string_to_type, StructField
+from .utils import AnalysisException, IllegalArgumentException
 
 
 class Column:

--- a/pysparkling/sql/column.py
+++ b/pysparkling/sql/column.py
@@ -14,7 +14,7 @@ from pysparkling.sql.types import DataType, string_to_type, StructField
 from pysparkling.sql.utils import AnalysisException, IllegalArgumentException
 
 
-class Column(object):
+class Column:
     """
     A column in a DataFrame.
 

--- a/pysparkling/sql/conf.py
+++ b/pysparkling/sql/conf.py
@@ -1,7 +1,7 @@
 _sentinel = object()
 
 
-class RuntimeConfig(object):
+class RuntimeConfig:
     def __init__(self, jconf=None):
         self._conf = {}
 

--- a/pysparkling/sql/context.py
+++ b/pysparkling/sql/context.py
@@ -1,7 +1,7 @@
 from pysparkling.sql.session import SparkSession
 
 
-class SQLContext(object):
+class SQLContext:
     _instantiatedContext = None
 
     def __init__(self, sparkContext, sparkSession=None, jsqlContext=None):

--- a/pysparkling/sql/context.py
+++ b/pysparkling/sql/context.py
@@ -1,4 +1,4 @@
-from pysparkling.sql.session import SparkSession
+from .session import SparkSession
 
 
 class SQLContext:

--- a/pysparkling/sql/dataframe.py
+++ b/pysparkling/sql/dataframe.py
@@ -1,15 +1,17 @@
 import warnings
 
-from pysparkling import StorageLevel
-from pysparkling.sql.column import Column, parse
-from pysparkling.sql.expressions.fields import FieldAsExpression
-from pysparkling.sql.internal_utils.joins import CROSS_JOIN, JOIN_TYPES
-from pysparkling.sql.internals import CUBE_TYPE, InternalGroupedDataFrame, ROLLUP_TYPE
-from pysparkling.sql.types import (
+from ..storagelevel import StorageLevel
+from .column import Column, parse
+from .expressions.fields import FieldAsExpression
+from .group import GroupedData
+from .internal_utils.joins import CROSS_JOIN, JOIN_TYPES
+from .internals import CUBE_TYPE, InternalGroupedDataFrame, ROLLUP_TYPE
+from .readwriter import DataFrameWriter
+from .types import (
     _check_series_convert_timestamps_local_tz, ByteType, FloatType, IntegerType, IntegralType, ShortType,
     TimestampType
 )
-from pysparkling.sql.utils import AnalysisException, IllegalArgumentException, require_minimum_pandas_version
+from .utils import AnalysisException, IllegalArgumentException, require_minimum_pandas_version
 
 _NoValue = object()
 
@@ -64,10 +66,6 @@ class DataFrame:
 
     @property
     def write(self):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.readwriter import DataFrameWriter
-
         return DataFrameWriter(self)
 
     @property
@@ -1121,9 +1119,6 @@ class DataFrame:
         | Carl|  5|    1|
         +-----+---+-----+
         """
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.group import GroupedData
         jgd = InternalGroupedDataFrame(self._jdf, [parse(c) for c in cols])
         return GroupedData(jgd, self)
 
@@ -1146,10 +1141,6 @@ class DataFrame:
         | Carl|   5|    1|
         +-----+----+-----+
         """
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.group import GroupedData
-
         jgd = InternalGroupedDataFrame(self._jdf, [parse(c) for c in cols], ROLLUP_TYPE)
         return GroupedData(jgd, self)
 
@@ -1190,10 +1181,6 @@ class DataFrame:
         +-----+----+-----+
 
         """
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.group import GroupedData
-
         jgd = InternalGroupedDataFrame(self._jdf, [parse(c) for c in cols], CUBE_TYPE)
         return GroupedData(jgd, self)
 

--- a/pysparkling/sql/dataframe.py
+++ b/pysparkling/sql/dataframe.py
@@ -14,7 +14,7 @@ from pysparkling.sql.utils import AnalysisException, IllegalArgumentException, r
 _NoValue = object()
 
 
-class DataFrame(object):
+class DataFrame:
     def __init__(self, jdf, sql_ctx):
         self._jdf = jdf
         self.sql_ctx = sql_ctx
@@ -1690,7 +1690,7 @@ class DataFrame(object):
         return self.filter(condition)
 
 
-class DataFrameNaFunctions(object):
+class DataFrameNaFunctions:
     def __init__(self, df):
         self.df = df
 
@@ -1710,7 +1710,7 @@ class DataFrameNaFunctions(object):
     replace.__doc__ = DataFrame.replace.__doc__
 
 
-class DataFrameStatFunctions(object):
+class DataFrameStatFunctions:
     def __init__(self, df):
         self.df = df
 

--- a/pysparkling/sql/dataframe.py
+++ b/pysparkling/sql/dataframe.py
@@ -6,7 +6,6 @@ from .expressions.fields import FieldAsExpression
 from .group import GroupedData
 from .internal_utils.joins import CROSS_JOIN, JOIN_TYPES
 from .internals import CUBE_TYPE, InternalGroupedDataFrame, ROLLUP_TYPE
-from .readwriter import DataFrameWriter
 from .types import (
     _check_series_convert_timestamps_local_tz, ByteType, FloatType, IntegerType, IntegralType, ShortType,
     TimestampType
@@ -66,6 +65,9 @@ class DataFrame:
 
     @property
     def write(self):
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from .readwriter import DataFrameWriter
+
         return DataFrameWriter(self)
 
     @property

--- a/pysparkling/sql/expressions/aggregate/aggregations.py
+++ b/pysparkling/sql/expressions/aggregate/aggregations.py
@@ -1,4 +1,4 @@
-from pysparkling.sql.expressions.expressions import Expression
+from ..expressions import Expression
 
 
 class Aggregation(Expression):

--- a/pysparkling/sql/expressions/aggregate/collectors.py
+++ b/pysparkling/sql/expressions/aggregate/collectors.py
@@ -1,4 +1,4 @@
-from pysparkling.sql.expressions.aggregate.aggregations import Aggregation
+from .aggregations import Aggregation
 
 
 class CollectList(Aggregation):

--- a/pysparkling/sql/expressions/aggregate/covariance_aggregations.py
+++ b/pysparkling/sql/expressions/aggregate/covariance_aggregations.py
@@ -1,11 +1,9 @@
-from pysparkling.sql.expressions.aggregate.aggregations import Aggregation
+from ....stat_counter import CovarianceCounter
+from .aggregations import Aggregation
 
 
 class CovarianceStatAggregation(Aggregation):
     def __init__(self, column1, column2):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.stat_counter import CovarianceCounter
         super().__init__(column1, column2)
         self.column1 = column1
         self.column2 = column2

--- a/pysparkling/sql/expressions/aggregate/stat_aggregations.py
+++ b/pysparkling/sql/expressions/aggregate/stat_aggregations.py
@@ -1,14 +1,12 @@
-from pysparkling.sql.column import Column
-from pysparkling.sql.expressions.aggregate.aggregations import Aggregation
-from pysparkling.sql.expressions.literals import Literal
-from pysparkling.sql.expressions.mappers import StarOperator
+from ....stat_counter import ColumnStatHelper
+from ...column import Column
+from ..literals import Literal
+from ..mappers import StarOperator
+from .aggregations import Aggregation
 
 
 class SimpleStatAggregation(Aggregation):
     def __init__(self, column):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.stat_counter import ColumnStatHelper
         super().__init__(column)
         self.column = column
         self.stat_helper = ColumnStatHelper(column)
@@ -30,9 +28,6 @@ class Count(SimpleStatAggregation):
     pretty_name = "count"
 
     def __init__(self, column):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.stat_counter import ColumnStatHelper
         if isinstance(column.expr, StarOperator):
             column = Column(Literal(1))
         super().__init__(column)

--- a/pysparkling/sql/expressions/arrays.py
+++ b/pysparkling/sql/expressions/arrays.py
@@ -1,5 +1,5 @@
-from pysparkling.sql.expressions.expressions import BinaryOperation, Expression, UnaryExpression
-from pysparkling.sql.utils import AnalysisException
+from ..utils import AnalysisException
+from .expressions import BinaryOperation, Expression, UnaryExpression
 
 
 class ArraysOverlap(BinaryOperation):

--- a/pysparkling/sql/expressions/csvs.py
+++ b/pysparkling/sql/expressions/csvs.py
@@ -1,7 +1,9 @@
-from pysparkling.sql.casts import NO_TIMESTAMP_CONVERSION
-from pysparkling.sql.expressions.expressions import Expression
-from pysparkling.sql.internal_utils.options import Options
-from pysparkling.sql.utils import AnalysisException
+from ..casts import NO_TIMESTAMP_CONVERSION
+from ..internal_utils.options import Options
+from ..internal_utils.readers.csvreader import csv_record_to_row, CSVReader
+from ..internal_utils.readers.utils import guess_schema_from_strings
+from ..utils import AnalysisException
+from .expressions import Expression
 
 sql_csv_function_options = dict(
     dateFormat=NO_TIMESTAMP_CONVERSION,
@@ -16,8 +18,6 @@ class SchemaOfCsv(Expression):
         super().__init__(column)
         self.column = column
         self.input_options = options
-        # pylint: disable=import-outside-toplevel; circular import
-        from pysparkling.sql.internal_utils.readers.csvreader import CSVReader
         self.options = Options(CSVReader.default_options, sql_csv_function_options, options)
 
     def eval(self, row, schema):
@@ -27,10 +27,6 @@ class SchemaOfCsv(Expression):
                 "type mismatch: The input csv should be a string literal and not null; "
                 "however, got {0}.".format(value)
             )
-        # pylint: disable=import-outside-toplevel; circular import
-        from pysparkling.sql.internal_utils.readers.csvreader import csv_record_to_row
-        from pysparkling.sql.internal_utils.readers.utils import guess_schema_from_strings
-
         record_as_row = csv_record_to_row(value, self.options)
         schema = guess_schema_from_strings(record_as_row.__fields__, [record_as_row], self.options)
         return schema.simpleString()

--- a/pysparkling/sql/expressions/dates.py
+++ b/pysparkling/sql/expressions/dates.py
@@ -3,10 +3,10 @@ import datetime
 from dateutil.relativedelta import relativedelta
 import pytz
 
-from pysparkling.sql.casts import get_time_formatter, get_unix_timestamp_parser
-from pysparkling.sql.expressions.expressions import Expression, UnaryExpression
-from pysparkling.sql.types import DateType, FloatType, TimestampType
-from pysparkling.utils import parse_tz
+from ...utils import parse_tz
+from ..casts import get_time_formatter, get_unix_timestamp_parser
+from ..types import DateType, FloatType, TimestampType
+from .expressions import Expression, UnaryExpression
 
 GMT_TIMEZONE = pytz.timezone("GMT")
 

--- a/pysparkling/sql/expressions/explodes.py
+++ b/pysparkling/sql/expressions/explodes.py
@@ -1,5 +1,5 @@
-from pysparkling.sql.expressions.expressions import UnaryExpression
-from pysparkling.sql.types import DataType, IntegerType, StructField
+from ..types import DataType, IntegerType, StructField
+from .expressions import UnaryExpression
 
 
 class Explode(UnaryExpression):

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -1,8 +1,6 @@
 from ..casts import get_caster
-from ..column import Column
 from ..types import DataType, INTERNAL_TYPE_ORDER, python_to_spark_type, StructField
 from ..utils import AnalysisException
-from .operators import Alias
 
 expression_registry = {}
 
@@ -85,6 +83,9 @@ class Expression(metaclass=RegisterExpressions):
         pass
 
     def recursive_merge_stats(self, other, schema):
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from .operators import Alias
+
         if isinstance(other.expr, Alias):
             self.recursive_merge_stats(other.expr.expr, schema)
         else:
@@ -93,6 +94,9 @@ class Expression(metaclass=RegisterExpressions):
 
     @staticmethod
     def children_merge_stats(children, other, schema):
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ..column import Column
+
         for child in children:
             if isinstance(child, Expression):
                 child.recursive_merge_stats(other, schema)
@@ -112,6 +116,9 @@ class Expression(metaclass=RegisterExpressions):
 
     @staticmethod
     def children_initialize(children, partition_index):
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ..column import Column
+
         for child in children:
             if isinstance(child, Expression):
                 child.recursive_initialize(partition_index)
@@ -133,6 +140,9 @@ class Expression(metaclass=RegisterExpressions):
 
     @staticmethod
     def children_pre_evaluation_schema(children, schema):
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ..column import Column
+
         for child in children:
             if isinstance(child, Expression):
                 child.recursive_pre_evaluation_schema(schema)

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -14,7 +14,7 @@ class RegisterExpressions(type):
             expression_registry[cls.pretty_name] = cls
 
 
-class Expression(object, metaclass=RegisterExpressions):
+class Expression(metaclass=RegisterExpressions):
     pretty_name = None
 
     def __init__(self, *children):

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -1,6 +1,8 @@
-from pysparkling.sql.casts import get_caster
-from pysparkling.sql.types import DataType, INTERNAL_TYPE_ORDER, python_to_spark_type, StructField
-from pysparkling.sql.utils import AnalysisException
+from ..casts import get_caster
+from ..column import Column
+from ..types import DataType, INTERNAL_TYPE_ORDER, python_to_spark_type, StructField
+from ..utils import AnalysisException
+from .operators import Alias
 
 expression_registry = {}
 
@@ -83,9 +85,6 @@ class Expression(metaclass=RegisterExpressions):
         pass
 
     def recursive_merge_stats(self, other, schema):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.expressions.operators import Alias
         if isinstance(other.expr, Alias):
             self.recursive_merge_stats(other.expr.expr, schema)
         else:
@@ -94,9 +93,6 @@ class Expression(metaclass=RegisterExpressions):
 
     @staticmethod
     def children_merge_stats(children, other, schema):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.column import Column
         for child in children:
             if isinstance(child, Expression):
                 child.recursive_merge_stats(other, schema)
@@ -116,9 +112,6 @@ class Expression(metaclass=RegisterExpressions):
 
     @staticmethod
     def children_initialize(children, partition_index):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.column import Column
         for child in children:
             if isinstance(child, Expression):
                 child.recursive_initialize(partition_index)
@@ -140,9 +133,6 @@ class Expression(metaclass=RegisterExpressions):
 
     @staticmethod
     def children_pre_evaluation_schema(children, schema):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.column import Column
         for child in children:
             if isinstance(child, Expression):
                 child.recursive_pre_evaluation_schema(schema)

--- a/pysparkling/sql/expressions/fields.py
+++ b/pysparkling/sql/expressions/fields.py
@@ -1,6 +1,6 @@
-from pysparkling.sql.expressions.expressions import Expression
-from pysparkling.sql.types import StructField
-from pysparkling.sql.utils import AnalysisException
+from ..types import StructField
+from ..utils import AnalysisException
+from .expressions import Expression
 
 
 class FieldAsExpression(Expression):

--- a/pysparkling/sql/expressions/jsons.py
+++ b/pysparkling/sql/expressions/jsons.py
@@ -1,8 +1,9 @@
 import json
 
-from pysparkling.sql.expressions.expressions import Expression
-from pysparkling.sql.internal_utils.options import Options
-from pysparkling.utils import get_json_encoder
+from ...utils import get_json_encoder
+from ..internal_utils.options import Options
+from ..internal_utils.readers.jsonreader import JSONReader
+from .expressions import Expression
 
 
 class StructsToJson(Expression):
@@ -16,8 +17,6 @@ class StructsToJson(Expression):
     def __init__(self, column, options):
         super().__init__(column)
         self.column = column
-        # pylint: disable=import-outside-toplevel; circular import
-        from pysparkling.sql.internal_utils.readers.jsonreader import JSONReader
         self.input_options = options
         self.options = Options(JSONReader.default_options, options)
         self.encoder = get_json_encoder(self.options)

--- a/pysparkling/sql/expressions/literals.py
+++ b/pysparkling/sql/expressions/literals.py
@@ -1,5 +1,5 @@
-from pysparkling.sql.expressions.expressions import Expression
-from pysparkling.sql.utils import AnalysisException
+from ..utils import AnalysisException
+from .expressions import Expression
 
 
 class Literal(Expression):

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -263,7 +263,7 @@ class IsNaN(UnaryExpression):
     pretty_name = "isnan"
 
     def eval(self, row, schema):
-        return self.eval(row, schema) is float("nan")
+        return math.isnan(self.eval(row, schema))
 
 
 class NaNvl(Expression):

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -4,11 +4,11 @@ import random
 import re
 import string
 
-from pysparkling.sql.expressions.expressions import Expression, NullSafeColumnOperation, UnaryExpression
-from pysparkling.sql.internal_utils.column import resolve_column
-from pysparkling.sql.types import create_row, StringType
-from pysparkling.sql.utils import AnalysisException
-from pysparkling.utils import half_even_round, half_up_round, MonotonicallyIncreasingIDGenerator, XORShiftRandom
+from ...utils import half_even_round, half_up_round, MonotonicallyIncreasingIDGenerator, XORShiftRandom
+from ..internal_utils.column import resolve_column
+from ..types import create_row, StringType
+from ..utils import AnalysisException
+from .expressions import Expression, NullSafeColumnOperation, UnaryExpression
 
 JVM_MAX_INTEGER_SIZE = 2 ** 63
 

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -962,7 +962,7 @@ class MonotonicallyIncreasingID(Expression):
         self.generator = None
 
     def eval(self, row, schema):
-        return self.generator.next()
+        return next(self.generator)
 
     def initialize(self, partition_index):
         self.generator = MonotonicallyIncreasingIDGenerator(partition_index)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -1,9 +1,6 @@
-from pysparkling import Row
-from pysparkling.sql.casts import get_caster
-from pysparkling.sql.expressions.expressions import (
-    BinaryOperation, Expression, NullSafeBinaryOperation, TypeSafeBinaryOperation, UnaryExpression
-)
-from pysparkling.sql.types import StructType
+from ..casts import get_caster
+from ..types import Row, StructType
+from .expressions import BinaryOperation, Expression, NullSafeBinaryOperation, TypeSafeBinaryOperation, UnaryExpression
 
 
 class Negate(UnaryExpression):

--- a/pysparkling/sql/expressions/orders.py
+++ b/pysparkling/sql/expressions/orders.py
@@ -1,4 +1,4 @@
-from pysparkling.sql.expressions.expressions import Expression
+from .expressions import Expression
 
 
 class SortOrder(Expression):

--- a/pysparkling/sql/expressions/strings.py
+++ b/pysparkling/sql/expressions/strings.py
@@ -1,8 +1,8 @@
 import string
 
-from pysparkling.sql.expressions.expressions import Expression, UnaryExpression
-from pysparkling.sql.types import StringType
-from pysparkling.utils import levenshtein_distance
+from ...utils import levenshtein_distance
+from ..types import StringType
+from .expressions import Expression, UnaryExpression
 
 
 class StringTrim(UnaryExpression):

--- a/pysparkling/sql/expressions/userdefined.py
+++ b/pysparkling/sql/expressions/userdefined.py
@@ -1,4 +1,4 @@
-from pysparkling.sql.expressions.expressions import Expression
+from .expressions import Expression
 
 
 class UserDefinedFunction(Expression):

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -1,28 +1,28 @@
 import math
 
-from pysparkling.sql.column import Column, ensure_column, parse
-from pysparkling.sql.expressions.aggregate.collectors import (
+from .column import Column, ensure_column, parse
+from .expressions.aggregate.collectors import (
     ApproxCountDistinct, CollectList, CollectSet, CountDistinct, First, Last, SumDistinct
 )
-from pysparkling.sql.expressions.aggregate.covariance_aggregations import Corr, CovarPop, CovarSamp
-from pysparkling.sql.expressions.aggregate.stat_aggregations import (
+from .expressions.aggregate.covariance_aggregations import Corr, CovarPop, CovarSamp
+from .expressions.aggregate.stat_aggregations import (
     Avg, Count, Kurtosis, Max, Min, Skewness, StddevPop, StddevSamp, Sum, VarPop, VarSamp
 )
-from pysparkling.sql.expressions.arrays import (
+from .expressions.arrays import (
     ArrayColumn, ArrayContains, ArrayDistinct, ArrayExcept, ArrayIntersect, ArrayJoin, ArrayMax, ArrayMin,
     ArrayPosition, ArrayRemove, ArrayRepeat, ArraySort, ArraysOverlap, ArraysZip, ArrayUnion, ElementAt, Flatten,
     MapColumn, MapFromArraysColumn, Sequence, Size, Slice, SortArray
 )
-from pysparkling.sql.expressions.csvs import SchemaOfCsv
-from pysparkling.sql.expressions.dates import (
+from .expressions.csvs import SchemaOfCsv
+from .expressions.dates import (
     AddMonths, CurrentDate, CurrentTimestamp, DateAdd, DateDiff, DateFormat, DateSub, DayOfMonth, DayOfWeek, DayOfYear,
     FromUnixTime, FromUTCTimestamp, Hour, LastDay, Minute, Month, MonthsBetween, NextDay, ParseToDate,
     ParseToTimestamp, Quarter, Second, ToUTCTimestamp, TruncDate, TruncTimestamp, UnixTimestamp, WeekOfYear, Year
 )
-from pysparkling.sql.expressions.explodes import Explode, ExplodeOuter, PosExplode, PosExplodeOuter
-from pysparkling.sql.expressions.jsons import StructsToJson
-from pysparkling.sql.expressions.literals import Literal
-from pysparkling.sql.expressions.mappers import (
+from .expressions.explodes import Explode, ExplodeOuter, PosExplode, PosExplodeOuter
+from .expressions.jsons import StructsToJson
+from .expressions.literals import Literal
+from .expressions.mappers import (
     Abs, Acos, Ascii, Asin, Atan, Atan2, Base64, Bin, Bround, CaseWhen, Cbrt, Ceil, Coalesce, Concat, ConcatWs, Conv,
     Cos, Cosh, CreateStruct, Exp, ExpM1, Factorial, Floor, FormatNumber, Greatest, Grouping, GroupingID, Hex, Hypot,
     InputFileName, IsNaN, Least, Length, Log, Log1p, Log2, Log10, Lower, MapConcat, MapEntries, MapFromEntries,
@@ -30,14 +30,14 @@ from pysparkling.sql.expressions.mappers import (
     Round, ShiftLeft, ShiftRight, ShiftRightUnsigned, Signum, Sin, Sinh, SparkPartitionID, Sqrt, StringSplit,
     SubstringIndex, Tan, Tanh, ToDegrees, ToRadians, UnBase64, Unhex, Upper
 )
-from pysparkling.sql.expressions.operators import BitwiseNot, IsNull, Pow, Substring
-from pysparkling.sql.expressions.strings import (
+from .expressions.operators import BitwiseNot, IsNull, Pow, Substring
+from .expressions.strings import (
     InitCap, Levenshtein, SoundEx, StringInStr, StringLocate, StringLPad, StringLTrim, StringRepeat, StringRPad,
     StringRTrim, StringTranslate, StringTrim
 )
-from pysparkling.sql.expressions.userdefined import UserDefinedFunction
-from pysparkling.sql.types import DataType
-from pysparkling.sql.utils import AnalysisException
+from .expressions.userdefined import UserDefinedFunction
+from .types import DataType
+from .utils import AnalysisException
 
 
 def col(colName):

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -967,11 +967,11 @@ def unhex(column):
     return col(Unhex(parse(column)))
 
 
-def hypot(l, r):
+def hypot(lst, r):
     """
     :rtype: Column
     """
-    return col(Hypot(parse(l), parse(r)))
+    return col(Hypot(parse(lst), parse(r)))
 
 
 def least(*exprs):
@@ -1016,11 +1016,11 @@ def log2(e):
 
 # noinspection PyShadowingBuiltins
 # pylint: disable=W0622
-def pow(l, r):
+def pow(lst, r):
     """
     :rtype: Column
     """
-    return col(Pow(parse(l), parse(r)))
+    return col(Pow(parse(lst), parse(r)))
 
 
 def rint(e):
@@ -1372,7 +1372,7 @@ def lower(e):
     return col(Lower(parse(e)))
 
 
-def levenshtein(l, r):
+def levenshtein(lst, r):
     """
     :rtype: Column
 
@@ -1387,7 +1387,7 @@ def levenshtein(l, r):
     +----------------------------+
 
     """
-    return col(Levenshtein(parse(l), parse(r)))
+    return col(Levenshtein(parse(lst), parse(r)))
 
 
 # noinspection PyShadowingBuiltins

--- a/pysparkling/sql/functions.py
+++ b/pysparkling/sql/functions.py
@@ -967,11 +967,11 @@ def unhex(column):
     return col(Unhex(parse(column)))
 
 
-def hypot(lst, r):
+def hypot(l, r):
     """
     :rtype: Column
     """
-    return col(Hypot(parse(lst), parse(r)))
+    return col(Hypot(parse(l), parse(r)))
 
 
 def least(*exprs):
@@ -1016,11 +1016,11 @@ def log2(e):
 
 # noinspection PyShadowingBuiltins
 # pylint: disable=W0622
-def pow(lst, r):
+def pow(l, r):
     """
     :rtype: Column
     """
-    return col(Pow(parse(lst), parse(r)))
+    return col(Pow(parse(l), parse(r)))
 
 
 def rint(e):
@@ -1372,7 +1372,7 @@ def lower(e):
     return col(Lower(parse(e)))
 
 
-def levenshtein(lst, r):
+def levenshtein(l, r):
     """
     :rtype: Column
 
@@ -1387,7 +1387,7 @@ def levenshtein(lst, r):
     +----------------------------+
 
     """
-    return col(Levenshtein(parse(lst), parse(r)))
+    return col(Levenshtein(parse(l), parse(r)))
 
 
 # noinspection PyShadowingBuiltins

--- a/pysparkling/sql/group.py
+++ b/pysparkling/sql/group.py
@@ -1,7 +1,7 @@
-from pysparkling.sql.column import Column
-from pysparkling.sql.dataframe import DataFrame
+from .column import Column
+from .dataframe import DataFrame
 # pylint: disable=W0622
-from pysparkling.sql.functions import avg, count, lit, max, mean, min, parse, sum
+from .functions import avg, count, lit, max, mean, min, parse, sum
 
 
 class GroupedData:

--- a/pysparkling/sql/group.py
+++ b/pysparkling/sql/group.py
@@ -1,5 +1,5 @@
-from .column import Column
 from . import functions as F
+from .column import Column
 
 
 class GroupedData:

--- a/pysparkling/sql/group.py
+++ b/pysparkling/sql/group.py
@@ -1,6 +1,5 @@
 from .column import Column
-from .dataframe import DataFrame
-# pylint: disable=W0622
+# pylint: disable=redefined-builtin
 from .functions import avg, count, lit, max, mean, min, parse, sum
 
 
@@ -49,6 +48,9 @@ class GroupedData:
 
             # noinspection PyProtectedMember
             jdf = self._jgd.agg([parse(e) for e in exprs])
+
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from .dataframe import DataFrame
 
         return DataFrame(jdf, self.sql_ctx)
 

--- a/pysparkling/sql/group.py
+++ b/pysparkling/sql/group.py
@@ -1,6 +1,5 @@
 from .column import Column
-# pylint: disable=redefined-builtin
-from .functions import avg, count, lit, max, mean, min, parse, sum
+from . import functions as F
 
 
 class GroupedData:
@@ -16,7 +15,7 @@ class GroupedData:
 
         >>> from pysparkling import Context, Row
         >>> from pysparkling.sql.session import SparkSession
-        >>> from pysparkling.sql.functions import col, avg
+        >>> from pysparkling.sql import functions as F
         >>> spark = SparkSession(Context())
         >>> df = spark.createDataFrame(
         ...   [Row(age=2, name='Alice'), Row(age=5, name='Bob')]
@@ -25,7 +24,7 @@ class GroupedData:
         >>> from pysparkling.sql import functions as F
         >>> sorted(gdf.agg(F.min(df.age)).collect())
         [Row(name='Alice', min(age)=2), Row(name='Bob', min(age)=5)]
-        >>> df.groupBy("age").agg(avg("age"), col("age")).show()
+        >>> df.groupBy("age").agg(F.avg("age"), F.col("age")).show()
         +---+--------+---+
         |age|avg(age)|age|
         +---+--------+---+
@@ -47,7 +46,7 @@ class GroupedData:
                 raise ValueError("all exprs should be Column")
 
             # noinspection PyProtectedMember
-            jdf = self._jgd.agg([parse(e) for e in exprs])
+            jdf = self._jgd.agg([F.parse(e) for e in exprs])
 
         # pylint: disable=import-outside-toplevel, cyclic-import
         from .dataframe import DataFrame
@@ -55,30 +54,30 @@ class GroupedData:
         return DataFrame(jdf, self.sql_ctx)
 
     def count(self):
-        return self.agg(count(lit(1)).alias("count"))
+        return self.agg(F.count(F.lit(1)).alias("count"))
 
     # pylint: disable=W0511
     # todo: avg, max, etc should work when cols is left empty
     def mean(self, *cols):
-        return self.agg(*(mean(parse(col)) for col in cols))
+        return self.agg(*(F.mean(F.parse(col)) for col in cols))
 
     def avg(self, *cols):
-        return self.agg(*(avg(parse(col)) for col in cols))
+        return self.agg(*(F.avg(F.parse(col)) for col in cols))
 
     def max(self, *cols):
-        return self.agg(*(max(parse(col)) for col in cols))
+        return self.agg(*(F.max(F.parse(col)) for col in cols))
 
     def min(self, *cols):
-        return self.agg(*(min(parse(col)) for col in cols))
+        return self.agg(*(F.min(F.parse(col)) for col in cols))
 
     def sum(self, *cols):
-        return self.agg(*(sum(parse(col)) for col in cols))
+        return self.agg(*(F.sum(F.parse(col)) for col in cols))
 
     def pivot(self, pivot_col, values=None):
         """
         >>> from pysparkling import Context, Row
         >>> from pysparkling.sql.session import SparkSession
-        >>> from pysparkling.sql.functions import col, avg, sum
+        >>> from pysparkling.sql import functions as F
         >>> sc = Context()
         >>> spark = SparkSession(sc)
         >>> df4 = sc.parallelize([Row(course="dotNET", year=2012, earnings=10000),
@@ -99,14 +98,14 @@ class GroupedData:
         |2012|20000| 15000|
         |2013|30000| 48000|
         +----+-----+------+
-        >>> df4.groupBy("year").pivot("course", ["dotNET", "PHP"]).agg(sum("earnings")).show()
+        >>> df4.groupBy("year").pivot("course", ["dotNET", "PHP"]).agg(F.sum("earnings")).show()
         +----+------+----+
         |year|dotNET| PHP|
         +----+------+----+
         |2012| 15000|null|
         |2013| 48000|null|
         +----+------+----+
-        >>> df4.groupBy("year").pivot("course").agg(sum("earnings"), avg("earnings")).show()
+        >>> df4.groupBy("year").pivot("course").agg(F.sum("earnings"), F.avg("earnings")).show()
         +----+------------------+------------------+--------------------+--------------------+
         |year|Java_sum(earnings)|Java_avg(earnings)|dotNET_sum(earnings)|dotNET_avg(earnings)|
         +----+------------------+------------------+--------------------+--------------------+
@@ -114,7 +113,7 @@ class GroupedData:
         |2013|             30000|           30000.0|               48000|             48000.0|
         +----+------------------+------------------+--------------------+--------------------+
         """
-        jgd = self._jgd.pivot(parse(pivot_col), values)
+        jgd = self._jgd.pivot(F.parse(pivot_col), values)
         return GroupedData(jgd, self._df)
 
     # pylint: disable=W0511

--- a/pysparkling/sql/group.py
+++ b/pysparkling/sql/group.py
@@ -4,7 +4,7 @@ from pysparkling.sql.dataframe import DataFrame
 from pysparkling.sql.functions import avg, count, lit, max, mean, min, parse, sum
 
 
-class GroupedData(object):
+class GroupedData:
     def __init__(self, jgd, df):
         self._jgd = jgd
         self._df = df

--- a/pysparkling/sql/group.py
+++ b/pysparkling/sql/group.py
@@ -91,7 +91,7 @@ class GroupedData:
         [Row(year=2012, Java=20000, dotNET=15000), Row(year=2013, Java=30000, dotNET=48000)]
         >>> df4.groupBy("year").pivot("course", ["dotNET"]).sum("earnings").collect()
         [Row(year=2012, dotNET=15000), Row(year=2013, dotNET=48000)]
-        >>> df4.groupBy("year").pivot("course").agg(sum("earnings")).show()
+        >>> df4.groupBy("year").pivot("course").agg(F.sum("earnings")).show()
         +----+-----+------+
         |year| Java|dotNET|
         +----+-----+------+

--- a/pysparkling/sql/group.py
+++ b/pysparkling/sql/group.py
@@ -1,4 +1,4 @@
-from . import functions as F
+from . import functions
 from .column import Column
 
 
@@ -15,16 +15,16 @@ class GroupedData:
 
         >>> from pysparkling import Context, Row
         >>> from pysparkling.sql.session import SparkSession
-        >>> from pysparkling.sql import functions as F
+        >>> from pysparkling.sql import functions
         >>> spark = SparkSession(Context())
         >>> df = spark.createDataFrame(
         ...   [Row(age=2, name='Alice'), Row(age=5, name='Bob')]
         ... )
         >>> gdf = df.groupBy(df.name)
-        >>> from pysparkling.sql import functions as F
-        >>> sorted(gdf.agg(F.min(df.age)).collect())
+        >>> from pysparkling.sql import functions
+        >>> sorted(gdf.agg(functions.min(df.age)).collect())
         [Row(name='Alice', min(age)=2), Row(name='Bob', min(age)=5)]
-        >>> df.groupBy("age").agg(F.avg("age"), F.col("age")).show()
+        >>> df.groupBy("age").agg(functions.avg("age"), functions.col("age")).show()
         +---+--------+---+
         |age|avg(age)|age|
         +---+--------+---+
@@ -46,7 +46,7 @@ class GroupedData:
                 raise ValueError("all exprs should be Column")
 
             # noinspection PyProtectedMember
-            jdf = self._jgd.agg([F.parse(e) for e in exprs])
+            jdf = self._jgd.agg([functions.parse(e) for e in exprs])
 
         # pylint: disable=import-outside-toplevel, cyclic-import
         from .dataframe import DataFrame
@@ -54,30 +54,30 @@ class GroupedData:
         return DataFrame(jdf, self.sql_ctx)
 
     def count(self):
-        return self.agg(F.count(F.lit(1)).alias("count"))
+        return self.agg(functions.count(functions.lit(1)).alias("count"))
 
     # pylint: disable=W0511
     # todo: avg, max, etc should work when cols is left empty
     def mean(self, *cols):
-        return self.agg(*(F.mean(F.parse(col)) for col in cols))
+        return self.agg(*(functions.mean(functions.parse(col)) for col in cols))
 
     def avg(self, *cols):
-        return self.agg(*(F.avg(F.parse(col)) for col in cols))
+        return self.agg(*(functions.avg(functions.parse(col)) for col in cols))
 
     def max(self, *cols):
-        return self.agg(*(F.max(F.parse(col)) for col in cols))
+        return self.agg(*(functions.max(functions.parse(col)) for col in cols))
 
     def min(self, *cols):
-        return self.agg(*(F.min(F.parse(col)) for col in cols))
+        return self.agg(*(functions.min(functions.parse(col)) for col in cols))
 
     def sum(self, *cols):
-        return self.agg(*(F.sum(F.parse(col)) for col in cols))
+        return self.agg(*(functions.sum(functions.parse(col)) for col in cols))
 
     def pivot(self, pivot_col, values=None):
         """
         >>> from pysparkling import Context, Row
         >>> from pysparkling.sql.session import SparkSession
-        >>> from pysparkling.sql import functions as F
+        >>> from pysparkling.sql import functions as functions
         >>> sc = Context()
         >>> spark = SparkSession(sc)
         >>> df4 = sc.parallelize([Row(course="dotNET", year=2012, earnings=10000),
@@ -91,21 +91,21 @@ class GroupedData:
         [Row(year=2012, Java=20000, dotNET=15000), Row(year=2013, Java=30000, dotNET=48000)]
         >>> df4.groupBy("year").pivot("course", ["dotNET"]).sum("earnings").collect()
         [Row(year=2012, dotNET=15000), Row(year=2013, dotNET=48000)]
-        >>> df4.groupBy("year").pivot("course").agg(F.sum("earnings")).show()
+        >>> df4.groupBy("year").pivot("course").agg(functions.sum("earnings")).show()
         +----+-----+------+
         |year| Java|dotNET|
         +----+-----+------+
         |2012|20000| 15000|
         |2013|30000| 48000|
         +----+-----+------+
-        >>> df4.groupBy("year").pivot("course", ["dotNET", "PHP"]).agg(F.sum("earnings")).show()
+        >>> df4.groupBy("year").pivot("course", ["dotNET", "PHP"]).agg(functions.sum("earnings")).show()
         +----+------+----+
         |year|dotNET| PHP|
         +----+------+----+
         |2012| 15000|null|
         |2013| 48000|null|
         +----+------+----+
-        >>> df4.groupBy("year").pivot("course").agg(F.sum("earnings"), F.avg("earnings")).show()
+        >>> df4.groupBy("year").pivot("course").agg(functions.sum("earnings"), functions.avg("earnings")).show()
         +----+------------------+------------------+--------------------+--------------------+
         |year|Java_sum(earnings)|Java_avg(earnings)|dotNET_sum(earnings)|dotNET_avg(earnings)|
         +----+------------------+------------------+--------------------+--------------------+
@@ -113,7 +113,7 @@ class GroupedData:
         |2013|             30000|           30000.0|               48000|             48000.0|
         +----+------------------+------------------+--------------------+--------------------+
         """
-        jgd = self._jgd.pivot(F.parse(pivot_col), values)
+        jgd = self._jgd.pivot(functions.parse(pivot_col), values)
         return GroupedData(jgd, self._df)
 
     # pylint: disable=W0511

--- a/pysparkling/sql/internal_utils/readers/__init__.py
+++ b/pysparkling/sql/internal_utils/readers/__init__.py
@@ -1,1 +1,1 @@
-from pysparkling.sql.internal_utils.readers.common import InternalReader
+from .common import InternalReader

--- a/pysparkling/sql/internal_utils/readers/__init__.py
+++ b/pysparkling/sql/internal_utils/readers/__init__.py
@@ -1,1 +1,5 @@
 from .common import InternalReader
+
+__all__ = [
+    'InternalReader'
+]

--- a/pysparkling/sql/internal_utils/readers/common.py
+++ b/pysparkling/sql/internal_utils/readers/common.py
@@ -1,8 +1,8 @@
-from pysparkling.sql.internal_utils.readers.csvreader import CSVReader
-from pysparkling.sql.internal_utils.readers.jsonreader import JSONReader
-from pysparkling.sql.internal_utils.readers.textreader import TextReader
-from pysparkling.sql.internal_utils.readwrite import OptionUtils, to_option_stored_value
-from pysparkling.sql.types import StructType
+from ...internal_utils.readers.csvreader import CSVReader
+from ...internal_utils.readers.jsonreader import JSONReader
+from ...internal_utils.readers.textreader import TextReader
+from ...internal_utils.readwrite import OptionUtils, to_option_stored_value
+from ...types import StructType
 
 
 class InternalReader(OptionUtils):

--- a/pysparkling/sql/internal_utils/readers/common.py
+++ b/pysparkling/sql/internal_utils/readers/common.py
@@ -1,6 +1,4 @@
-from ...internal_utils.readers.csvreader import CSVReader
-from ...internal_utils.readers.jsonreader import JSONReader
-from ...internal_utils.readers.textreader import TextReader
+from ...internal_utils.readers import csvreader, jsonreader, textreader
 from ...internal_utils.readwrite import OptionUtils, to_option_stored_value
 from ...types import StructType
 
@@ -24,10 +22,10 @@ class InternalReader(OptionUtils):
         self._schema = None
 
     def csv(self, paths):
-        return CSVReader(self._spark, paths, self._schema, self._options).read()
+        return csvreader.CSVReader(self._spark, paths, self._schema, self._options).read()
 
     def json(self, paths):
-        return JSONReader(self._spark, paths, self._schema, self._options).read()
+        return jsonreader.JSONReader(self._spark, paths, self._schema, self._options).read()
 
     def text(self, paths):
-        return TextReader(self._spark, paths, self._schema, self._options).read()
+        return textreader.TextReader(self._spark, paths, self._schema, self._options).read()

--- a/pysparkling/sql/internal_utils/readers/csvreader.py
+++ b/pysparkling/sql/internal_utils/readers/csvreader.py
@@ -10,7 +10,7 @@ from pysparkling.sql.schema_utils import infer_schema_from_rdd
 from pysparkling.sql.types import create_row, StringType, StructField, StructType
 
 
-class CSVReader(object):
+class CSVReader:
     default_options = dict(
         lineSep=None,
         encoding="utf-8",

--- a/pysparkling/sql/internal_utils/readers/csvreader.py
+++ b/pysparkling/sql/internal_utils/readers/csvreader.py
@@ -1,13 +1,13 @@
 from functools import partial
 import itertools
 
-from pysparkling.fileio import TextFile
-from pysparkling.sql.casts import get_caster
-from pysparkling.sql.internal_utils.options import Options
-from pysparkling.sql.internal_utils.readers.utils import guess_schema_from_strings, resolve_partitions
-from pysparkling.sql.internals import DataFrameInternal
-from pysparkling.sql.schema_utils import infer_schema_from_rdd
-from pysparkling.sql.types import create_row, StringType, StructField, StructType
+from ....fileio import TextFile
+from ...casts import get_caster
+from ...internal_utils.options import Options
+from ...internal_utils.readers.utils import guess_schema_from_strings, resolve_partitions
+from ...internals import DataFrameInternal
+from ...schema_utils import infer_schema_from_rdd
+from ...types import create_row, StringType, StructField, StructType
 
 
 class CSVReader:

--- a/pysparkling/sql/internal_utils/readers/csvreader.py
+++ b/pysparkling/sql/internal_utils/readers/csvreader.py
@@ -5,7 +5,6 @@ from ....fileio import TextFile
 from ...casts import get_caster
 from ...internal_utils.options import Options
 from ...internal_utils.readers.utils import guess_schema_from_strings, resolve_partitions
-from ...internals import DataFrameInternal
 from ...schema_utils import infer_schema_from_rdd
 from ...types import create_row, StringType, StructField, StructType
 
@@ -63,6 +62,9 @@ class CSVReader:
         )
         casted_rdd = rdd.map(cast_row)
         casted_rdd._name = paths
+
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ...internals import DataFrameInternal
 
         return DataFrameInternal(
             sc,

--- a/pysparkling/sql/internal_utils/readers/jsonreader.py
+++ b/pysparkling/sql/internal_utils/readers/jsonreader.py
@@ -10,7 +10,7 @@ from pysparkling.sql.schema_utils import infer_schema_from_rdd
 from pysparkling.sql.types import create_row, row_from_keyed_values, StructType
 
 
-class JSONReader(object):
+class JSONReader:
     default_options = dict(
         primitivesAsString=False,
         prefersDecimal=False,

--- a/pysparkling/sql/internal_utils/readers/jsonreader.py
+++ b/pysparkling/sql/internal_utils/readers/jsonreader.py
@@ -2,12 +2,12 @@ from functools import partial
 import itertools
 import json
 
-from pysparkling.sql.casts import get_struct_caster
-from pysparkling.sql.internal_utils.options import Options
-from pysparkling.sql.internal_utils.readers.utils import get_records, resolve_partitions
-from pysparkling.sql.internals import DataFrameInternal
-from pysparkling.sql.schema_utils import infer_schema_from_rdd
-from pysparkling.sql.types import create_row, row_from_keyed_values, StructType
+from ...casts import get_struct_caster
+from ...internal_utils.options import Options
+from ...internal_utils.readers.utils import get_records, resolve_partitions
+from ...internals import DataFrameInternal
+from ...schema_utils import infer_schema_from_rdd
+from ...types import create_row, row_from_keyed_values, StructType
 
 
 class JSONReader:

--- a/pysparkling/sql/internal_utils/readers/jsonreader.py
+++ b/pysparkling/sql/internal_utils/readers/jsonreader.py
@@ -5,7 +5,6 @@ import json
 from ...casts import get_struct_caster
 from ...internal_utils.options import Options
 from ...internal_utils.readers.utils import get_records, resolve_partitions
-from ...internals import DataFrameInternal
 from ...schema_utils import infer_schema_from_rdd
 from ...types import create_row, row_from_keyed_values, StructType
 
@@ -73,6 +72,9 @@ class JSONReader:
         cast_row = get_struct_caster(inferred_schema, full_schema, options=self.options)
         casted_rdd = rdd.map(cast_row)
         casted_rdd._name = paths
+
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ...internals import DataFrameInternal
 
         return DataFrameInternal(
             sc,

--- a/pysparkling/sql/internal_utils/readers/textreader.py
+++ b/pysparkling/sql/internal_utils/readers/textreader.py
@@ -1,11 +1,11 @@
 from functools import partial
 import itertools
 
-from pysparkling.fileio import TextFile
-from pysparkling.sql.internal_utils.options import Options
-from pysparkling.sql.internal_utils.readers.utils import resolve_partitions
-from pysparkling.sql.internals import DataFrameInternal
-from pysparkling.sql.types import create_row, StringType, StructField, StructType
+from ....fileio import TextFile
+from ...internal_utils.options import Options
+from ...internal_utils.readers.utils import resolve_partitions
+from ...internals import DataFrameInternal
+from ...types import create_row, StringType, StructField, StructType
 
 
 class TextReader:

--- a/pysparkling/sql/internal_utils/readers/textreader.py
+++ b/pysparkling/sql/internal_utils/readers/textreader.py
@@ -4,7 +4,6 @@ import itertools
 from ....fileio import TextFile
 from ...internal_utils.options import Options
 from ...internal_utils.readers.utils import resolve_partitions
-from ...internals import DataFrameInternal
 from ...types import create_row, StringType, StructField, StructType
 
 
@@ -45,6 +44,9 @@ class TextReader:
             full_schema = self.schema
 
         rdd._name = paths
+
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ...internals import DataFrameInternal
 
         return DataFrameInternal(
             sc,

--- a/pysparkling/sql/internal_utils/readers/textreader.py
+++ b/pysparkling/sql/internal_utils/readers/textreader.py
@@ -8,7 +8,7 @@ from pysparkling.sql.internals import DataFrameInternal
 from pysparkling.sql.types import create_row, StringType, StructField, StructType
 
 
-class TextReader(object):
+class TextReader:
     default_options = dict(
         lineSep=None,
         encoding="utf-8",

--- a/pysparkling/sql/internal_utils/readers/utils.py
+++ b/pysparkling/sql/internal_utils/readers/utils.py
@@ -1,10 +1,10 @@
-from pysparkling.fileio import File, TextFile
-from pysparkling.sql.casts import get_caster
-from pysparkling.sql.types import (
+from ....fileio import File, TextFile
+from ...casts import get_caster
+from ...types import (
     DecimalType, DoubleType, IntegerType, LongType, row_from_keyed_values, StringType, StructField, StructType,
     TimestampType
 )
-from pysparkling.sql.utils import AnalysisException
+from ...utils import AnalysisException
 
 
 def resolve_partitions(patterns):

--- a/pysparkling/sql/internal_utils/readwrite.py
+++ b/pysparkling/sql/internal_utils/readwrite.py
@@ -9,7 +9,7 @@ def to_option_stored_value(value):
     return str(value)
 
 
-class OptionUtils(object):
+class OptionUtils:
     def _set_opts(self, schema=None, **options):
         """
         Set named options (filter out those the value is None)

--- a/pysparkling/sql/internal_utils/readwrite.py
+++ b/pysparkling/sql/internal_utils/readwrite.py
@@ -1,4 +1,4 @@
-from pysparkling.sql.utils import IllegalArgumentException
+from ..utils import IllegalArgumentException
 
 
 def to_option_stored_value(value):

--- a/pysparkling/sql/internal_utils/writers.py
+++ b/pysparkling/sql/internal_utils/writers.py
@@ -4,15 +4,15 @@ import json
 import os
 import shutil
 
-from pysparkling import Row
-from pysparkling.sql.casts import cast_to_string
-from pysparkling.sql.expressions.aggregate.aggregations import Aggregation
-from pysparkling.sql.expressions.mappers import StarOperator
-from pysparkling.sql.functions import col
-from pysparkling.sql.internal_utils.options import Options
-from pysparkling.sql.internal_utils.readwrite import to_option_stored_value
-from pysparkling.sql.utils import AnalysisException
-from pysparkling.utils import get_json_encoder, portable_hash
+from ...utils import get_json_encoder, portable_hash
+from ..casts import cast_to_string
+from ..expressions.aggregate.aggregations import Aggregation
+from ..expressions.mappers import StarOperator
+from ..functions import col
+from ..internal_utils.options import Options
+from ..internal_utils.readwrite import to_option_stored_value
+from ..types import Row
+from ..utils import AnalysisException
 
 
 class InternalWriter:

--- a/pysparkling/sql/internal_utils/writers.py
+++ b/pysparkling/sql/internal_utils/writers.py
@@ -15,7 +15,7 @@ from pysparkling.sql.utils import AnalysisException
 from pysparkling.utils import get_json_encoder, portable_hash
 
 
-class InternalWriter(object):
+class InternalWriter:
     def __init__(self, df):
         self._df = df
         self._source = "parquet"
@@ -114,7 +114,7 @@ class WriteInFolder(Aggregation):
         return (self.column,)
 
 
-class DataWriter(object):
+class DataWriter:
     default_options = dict(
         dateFormat="yyyy-MM-dd",
         timestampFormat="yyyy-MM-dd'T'HH:mm:ss.SSSXXX",

--- a/pysparkling/sql/internals.py
+++ b/pysparkling/sql/internals.py
@@ -6,23 +6,21 @@ import json
 import math
 import warnings
 
-from pysparkling import StorageLevel
-from pysparkling.sql.column import parse
-from pysparkling.sql.functions import array, collect_set, count, lit, map_from_arrays, rand, struct
-from pysparkling.sql.internal_utils.column import resolve_column
-from pysparkling.sql.internal_utils.joins import (
-    CROSS_JOIN, FULL_JOIN, INNER_JOIN, LEFT_ANTI_JOIN, LEFT_JOIN, LEFT_SEMI_JOIN, RIGHT_JOIN
-)
-from pysparkling.sql.schema_utils import get_schema_from_cols, infer_schema_from_rdd, merge_schemas
-from pysparkling.sql.types import (
-    create_row, DataType, LongType, Row, row_from_keyed_values, StringType, StructField, StructType
-)
-from pysparkling.sql.utils import IllegalArgumentException
-from pysparkling.stat_counter import CovarianceCounter, RowStatHelper
-from pysparkling.utils import (
+from ..stat_counter import CovarianceCounter, RowStatHelper
+from ..storagelevel import StorageLevel
+from ..utils import (
     compute_weighted_percentiles, format_cell, get_keyfunc, merge_rows, merge_rows_joined_on_values, pad_cell,
     portable_hash, reservoir_sample_and_size, str_half_width
 )
+from .column import parse
+from .functions import array, collect_set, count, lit, map_from_arrays, rand, struct
+from .internal_utils.column import resolve_column
+from .internal_utils.joins import (
+    CROSS_JOIN, FULL_JOIN, INNER_JOIN, LEFT_ANTI_JOIN, LEFT_JOIN, LEFT_SEMI_JOIN, RIGHT_JOIN
+)
+from .schema_utils import get_schema_from_cols, infer_schema_from_rdd, merge_schemas
+from .types import create_row, DataType, LongType, Row, row_from_keyed_values, StringType, StructField, StructType
+from .utils import IllegalArgumentException
 
 
 class FieldIdGenerator:

--- a/pysparkling/sql/internals.py
+++ b/pysparkling/sql/internals.py
@@ -25,7 +25,7 @@ from pysparkling.utils import (
 )
 
 
-class FieldIdGenerator(object):
+class FieldIdGenerator:
     """
     This metaclass adds an unique ID to all instances of its classes.
 
@@ -64,7 +64,7 @@ class FieldIdGenerator(object):
         return schema
 
 
-class DataFrameInternal(object):
+class DataFrameInternal:
     def __init__(self, sc, rdd, cols=None, convert_to_row=False, schema=None):
         """
         :type rdd: RDD
@@ -974,7 +974,7 @@ class SubTotalValue:
 GROUPED = SubTotalValue()
 
 
-class InternalGroupedDataFrame(object):
+class InternalGroupedDataFrame:
     def __init__(self,
                  jdf, grouping_cols, group_type=GROUP_BY_TYPE,
                  pivot_col=None, pivot_values=None):
@@ -1141,7 +1141,7 @@ class InternalGroupedDataFrame(object):
         )
 
 
-class GroupedStats(object):
+class GroupedStats:
     def __init__(self, grouping_cols, stats, pivot_col, pivot_values, groups=None):
         self.grouping_cols = grouping_cols
         self.stats = stats

--- a/pysparkling/sql/readwriter.py
+++ b/pysparkling/sql/readwriter.py
@@ -1,9 +1,9 @@
-from pysparkling import RDD
-from pysparkling.sql.dataframe import DataFrame
-from pysparkling.sql.internal_utils.readers import InternalReader
-from pysparkling.sql.internal_utils.readwrite import OptionUtils
-from pysparkling.sql.internal_utils.writers import CSVWriter, InternalWriter, JSONWriter
-from pysparkling.sql.utils import IllegalArgumentException
+from ..rdd import RDD
+from .dataframe import DataFrame
+from .internal_utils.readers import InternalReader
+from .internal_utils.readwrite import OptionUtils
+from .internal_utils.writers import CSVWriter, InternalWriter, JSONWriter
+from .utils import IllegalArgumentException
 
 WRITE_MODES = ("overwrite", "append", "ignore", "error", "errorifexists")
 DATA_WRITERS = dict(

--- a/pysparkling/sql/readwriter.py
+++ b/pysparkling/sql/readwriter.py
@@ -1,3 +1,4 @@
+from ..rdd import RDD
 from .dataframe import DataFrame
 from .internal_utils.readers import InternalReader
 from .internal_utils.readwrite import OptionUtils
@@ -37,9 +38,6 @@ class DataFrameReader(OptionUtils):
 
         if isinstance(path, list):
             return self._df(method_to_read_if_rdd(path))
-
-        # pylint: disable=import-outside-toplevel, cyclic-import
-        from ..rdd import RDD
 
         if isinstance(path, RDD):
             return self._df(method_to_read_if_rdd(path.collect()))

--- a/pysparkling/sql/readwriter.py
+++ b/pysparkling/sql/readwriter.py
@@ -1,4 +1,3 @@
-from ..rdd import RDD
 from .dataframe import DataFrame
 from .internal_utils.readers import InternalReader
 from .internal_utils.readwrite import OptionUtils
@@ -38,6 +37,9 @@ class DataFrameReader(OptionUtils):
 
         if isinstance(path, list):
             return self._df(method_to_read_if_rdd(path))
+
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ..rdd import RDD
 
         if isinstance(path, RDD):
             return self._df(method_to_read_if_rdd(path.collect()))

--- a/pysparkling/sql/schema_utils.py
+++ b/pysparkling/sql/schema_utils.py
@@ -1,10 +1,10 @@
 from functools import reduce
 
-from pysparkling.sql.internal_utils.joins import (
+from .internal_utils.joins import (
     CROSS_JOIN, FULL_JOIN, INNER_JOIN, LEFT_ANTI_JOIN, LEFT_JOIN, LEFT_SEMI_JOIN, RIGHT_JOIN
 )
-from pysparkling.sql.types import _get_null_fields, _has_nulltype, _infer_schema, _merge_type, StructField, StructType
-from pysparkling.sql.utils import IllegalArgumentException
+from .types import _get_null_fields, _has_nulltype, _infer_schema, _merge_type, StructField, StructType
+from .utils import IllegalArgumentException
 
 
 def infer_schema_from_rdd(rdd):

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -2,7 +2,6 @@ from threading import RLock
 
 from ..__version__ import __version__
 from ..context import Context
-from ..rdd import RDD
 from .conf import RuntimeConfig
 from .dataframe import DataFrame
 from .internals import DataFrameInternal
@@ -31,8 +30,10 @@ class SparkSession:
     builder = Builder()
 
     def __init__(self, sparkContext, jsparkSession=None):
-        self._sc = sparkContext
+        # pylint: disable=import-outside-toplevel, cyclic-import
         from .context import SQLContext
+
+        self._sc = sparkContext
         self._wrapped = SQLContext(self._sc, self)
         SparkSession._instantiatedSession = self
         SparkSession._activeSession = self
@@ -258,6 +259,9 @@ class SparkSession:
         else:
             def prepare(obj):
                 return obj
+
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ..rdd import RDD
 
         if isinstance(data, RDD):
             rdd, schema = self._createFromRDD(data.map(prepare), schema, samplingRatio)

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -14,8 +14,8 @@ from pysparkling.sql.types import (
 from pysparkling.sql.utils import require_minimum_pandas_version
 
 
-class SparkSession(object):
-    class Builder(object):
+class SparkSession:
+    class Builder:
         _lock = RLock()
 
         def getOrCreate(self):

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -1,17 +1,17 @@
 from threading import RLock
 
-import pysparkling
-from pysparkling import RDD
-from pysparkling.context import Context
-from pysparkling.sql.conf import RuntimeConfig
-from pysparkling.sql.dataframe import DataFrame
-from pysparkling.sql.internals import DataFrameInternal
-from pysparkling.sql.readwriter import DataFrameReader
-from pysparkling.sql.schema_utils import infer_schema_from_list
-from pysparkling.sql.types import (
+from ..__version__ import __version__
+from ..context import Context
+from ..rdd import RDD
+from .conf import RuntimeConfig
+from .dataframe import DataFrame
+from .internals import DataFrameInternal
+from .readwriter import DataFrameReader
+from .schema_utils import infer_schema_from_list
+from .types import (
     _create_converter, _has_nulltype, _infer_schema, _make_type_verifier, _merge_type, DataType, StructType
 )
-from pysparkling.sql.utils import require_minimum_pandas_version
+from .utils import require_minimum_pandas_version
 
 
 class SparkSession:
@@ -31,10 +31,8 @@ class SparkSession:
     builder = Builder()
 
     def __init__(self, sparkContext, jsparkSession=None):
-        # Top level import would cause cyclic dependencies
-        # pylint: disable=import-outside-toplevel
-        from pysparkling.sql.context import SQLContext
         self._sc = sparkContext
+        from .context import SQLContext
         self._wrapped = SQLContext(self._sc, self)
         SparkSession._instantiatedSession = self
         SparkSession._activeSession = self
@@ -58,7 +56,7 @@ class SparkSession:
 
     @property
     def version(self):
-        return pysparkling.__version__
+        return __version__
 
     @property
     def conf(self):
@@ -82,7 +80,7 @@ class SparkSession:
 
         :return: :class:`Catalog`
         """
-        # from pysparkling.sql.catalog import Catalog
+        # from .catalog import Catalog
         # if not hasattr(self, "_catalog"):
         #     # Compatibility with Pyspark behavior
         #     # noinspection PyAttributeOutsideInit
@@ -95,7 +93,7 @@ class SparkSession:
         # pylint: disable=W0511
         # todo: Add support of udf registration
         raise NotImplementedError("Pysparkling does not support yet catalog")
-        # from pysparkling.sql.udf import UDFRegistration
+        # from .udf import UDFRegistration
         # return UDFRegistration(self)
 
     def _inferSchema(self, rdd, samplingRatio=None, names=None):
@@ -104,7 +102,7 @@ class SparkSession:
 
         :param rdd: an RDD of Row or tuple
         :param samplingRatio: sampling ratio, or no sampling (default)
-        :return: :class:`pysparkling.sql.types.StructType`
+        :return: :class:`.types.StructType`
         """
         first = rdd.first()
         if not first:

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -1,7 +1,8 @@
 from threading import RLock
 
-from .. import Context, RDD
 from ..__version__ import __version__
+from ..context import Context
+from ..rdd import RDD
 from .conf import RuntimeConfig
 from .dataframe import DataFrame
 from .internals import DataFrameInternal

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -1,7 +1,7 @@
 from threading import RLock
 
+from .. import Context, RDD
 from ..__version__ import __version__
-from ..context import Context
 from .conf import RuntimeConfig
 from .dataframe import DataFrame
 from .internals import DataFrameInternal
@@ -259,9 +259,6 @@ class SparkSession:
         else:
             def prepare(obj):
                 return obj
-
-        # pylint: disable=import-outside-toplevel, cyclic-import
-        from ..rdd import RDD
 
         if isinstance(data, RDD):
             rdd, schema = self._createFromRDD(data.map(prepare), schema, samplingRatio)

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -1,6 +1,6 @@
 from threading import RLock
 
-from .. import __version__
+from ..__version__ import __version__
 from ..context import Context
 from ..rdd import RDD
 from .conf import RuntimeConfig

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -2,6 +2,7 @@ from threading import RLock
 
 from ..__version__ import __version__
 from ..context import Context
+from ..rdd import RDD
 from .conf import RuntimeConfig
 from .dataframe import DataFrame
 from .internals import DataFrameInternal
@@ -259,9 +260,6 @@ class SparkSession:
         else:
             def prepare(obj):
                 return obj
-
-        # pylint: disable=import-outside-toplevel, cyclic-import
-        from ..rdd import RDD
 
         if isinstance(data, RDD):
             rdd, schema = self._createFromRDD(data.map(prepare), schema, samplingRatio)

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -1,6 +1,6 @@
 from threading import RLock
 
-from ..__version__ import __version__
+from .. import __version__
 from ..context import Context
 from ..rdd import RDD
 from .conf import RuntimeConfig

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -2,7 +2,6 @@ from threading import RLock
 
 from ..__version__ import __version__
 from ..context import Context
-from ..rdd import RDD
 from .conf import RuntimeConfig
 from .dataframe import DataFrame
 from .internals import DataFrameInternal
@@ -260,6 +259,9 @@ class SparkSession:
         else:
             def prepare(obj):
                 return obj
+
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from ..rdd import RDD
 
         if isinstance(data, RDD):
             rdd, schema = self._createFromRDD(data.map(prepare), schema, samplingRatio)

--- a/pysparkling/sql/tests/expressions/test_mappers.py
+++ b/pysparkling/sql/tests/expressions/test_mappers.py
@@ -12,7 +12,7 @@ class MonotonicallyIncreasingIDGeneratorTests(TestCase):
         self.assertEqual(sut.value, 8589934592 - 1)  # I do it this way so I can easily find/replace the value
 
         sut = MonotonicallyIncreasingIDGenerator(2)
-        self.assertEqual(sut.value, 2*8589934592 - 1)
+        self.assertEqual(sut.value, 2 * 8589934592 - 1)
 
     def test_next_value_ok(self):
         sut = MonotonicallyIncreasingIDGenerator(1)

--- a/pysparkling/sql/tests/expressions/test_mappers.py
+++ b/pysparkling/sql/tests/expressions/test_mappers.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+from pysparkling.utils import MonotonicallyIncreasingIDGenerator
+
+
+class MonotonicallyIncreasingIDGeneratorTests(TestCase):
+    def test_init_ok(self):
+        sut = MonotonicallyIncreasingIDGenerator(0)
+        self.assertEqual(sut.value, -1)  # Shouldn't we throw an error here?
+
+        sut = MonotonicallyIncreasingIDGenerator(1)
+        self.assertEqual(sut.value, 8589934592 - 1)  # I do it this way so I can easily find/replace the value
+
+        sut = MonotonicallyIncreasingIDGenerator(2)
+        self.assertEqual(sut.value, 2*8589934592 - 1)
+
+    def test_next_value_ok(self):
+        sut = MonotonicallyIncreasingIDGenerator(1)
+        self.assertEqual(next(sut), 8589934592)
+        self.assertEqual(next(sut), 8589934593)
+        self.assertEqual(next(sut), 8589934594)

--- a/pysparkling/sql/types.py
+++ b/pysparkling/sql/types.py
@@ -24,7 +24,7 @@ import os
 import re
 import sys
 
-from pysparkling.sql.utils import ParseException, require_minimum_pandas_version
+from .utils import ParseException, require_minimum_pandas_version
 
 __all__ = [
     "DataType", "NullType", "StringType", "BinaryType", "BooleanType", "DateType",

--- a/pysparkling/sql/types.py
+++ b/pysparkling/sql/types.py
@@ -1205,8 +1205,9 @@ def _create_converter(dataType):
             raise TypeError("Unexpected obj type: %s" % type(obj))
 
         if convert_fields:
-            return tuple([convert(d.get(name)) for name, convert in zip(names, converters)])
-        return tuple([d.get(name) for name in names])
+            return tuple(convert(d.get(name)) for name, convert in zip(names, converters))
+
+        return tuple(d.get(name) for name in names)
 
     return convert_struct
 

--- a/pysparkling/sql/types.py
+++ b/pysparkling/sql/types.py
@@ -33,7 +33,7 @@ __all__ = [
 ]
 
 
-class DataType(object):
+class DataType:
     """Base class for data types."""
 
     def __repr__(self):

--- a/pysparkling/stat_counter.py
+++ b/pysparkling/stat_counter.py
@@ -22,8 +22,8 @@ import copy
 import math
 import numbers
 
-from pysparkling.sql.functions import parse
-from pysparkling.sql.types import row_from_keyed_values
+from .sql.functions import parse
+from .sql.types import row_from_keyed_values
 
 try:
     from numpy import maximum, minimum, sqrt

--- a/pysparkling/stat_counter.py
+++ b/pysparkling/stat_counter.py
@@ -22,7 +22,7 @@ import copy
 import math
 import numbers
 
-from .sql.functions import parse
+from .sql.column import parse
 from .sql.types import row_from_keyed_values
 
 try:

--- a/pysparkling/stat_counter.py
+++ b/pysparkling/stat_counter.py
@@ -36,7 +36,7 @@ except ImportError:
     sqrt = math.sqrt
 
 
-class StatCounter(object):
+class StatCounter:
 
     def __init__(self, values=None):
         self.n = 0  # Running count of our values
@@ -148,7 +148,7 @@ class StatCounter(object):
 PercentileStats = namedtuple("PercentileStats", ["value", "g", "delta"])
 
 
-class ColumnStatHelper(object):
+class ColumnStatHelper:
     """
     This class is used to compute statistics on a column
 
@@ -449,7 +449,7 @@ class ColumnStatHelper(object):
         return self.count * self.m4 / (self.m2 * self.m2) - 3
 
 
-class RowStatHelper(object):
+class RowStatHelper:
     """
     Class use to maintain one ColumnStatHelper for each Column found when aggregating a list of Rows
     """
@@ -535,7 +535,7 @@ class RowStatHelper(object):
         return str(stat) if stat is not None else None
 
 
-class CovarianceCounter(object):
+class CovarianceCounter:
     def __init__(self, method):
         if method != "pearson":
             raise ValueError(

--- a/pysparkling/storagelevel.py
+++ b/pysparkling/storagelevel.py
@@ -18,7 +18,7 @@
 __all__ = ["StorageLevel"]
 
 
-class StorageLevel(object):
+class StorageLevel:
 
     """
     Flags for controlling the storage of an RDD. Each StorageLevel records whether to use memory,

--- a/pysparkling/streaming/context.py
+++ b/pysparkling/streaming/context.py
@@ -30,7 +30,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-class StreamingContext(object):
+class StreamingContext:
     """Stream processing.
 
     :param pysparkling.Context sparkContext: A pysparkling.Context.

--- a/pysparkling/streaming/dstream.py
+++ b/pysparkling/streaming/dstream.py
@@ -9,7 +9,7 @@ from ..rdd import EmptyRDD
 log = logging.getLogger(__name__)
 
 
-class DStream(object):
+class DStream:
     """A discrete stream of RDDs.
 
     Usually a DStream is created by a

--- a/pysparkling/streaming/filestream.py
+++ b/pysparkling/streaming/filestream.py
@@ -8,7 +8,7 @@ from ..rdd import EmptyRDD
 log = logging.getLogger(__name__)
 
 
-class FileTextStreamDeserializer(object):
+class FileTextStreamDeserializer:
     def __init__(self, context):
         self.context = context
 
@@ -19,7 +19,7 @@ class FileTextStreamDeserializer(object):
         return self.context.textFile(path)
 
 
-class FileBinaryStreamDeserializer(object):
+class FileBinaryStreamDeserializer:
     def __init__(self, context, recordLength=None):
         self.context = context
         self.record_length = recordLength
@@ -32,7 +32,7 @@ class FileBinaryStreamDeserializer(object):
             path, recordLength=self.record_length)
 
 
-class FileStream(object):
+class FileStream:
     def __init__(self, path, process_all=False):
         self.path = path
         self.files_done = set()

--- a/pysparkling/streaming/queuestream.py
+++ b/pysparkling/streaming/queuestream.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from ..rdd import EmptyRDD, RDD
 
 
-class QueueStreamDeserializer(object):
+class QueueStreamDeserializer:
     def __init__(self, context):
         self.context = context
 
@@ -18,7 +18,7 @@ class QueueStreamDeserializer(object):
         return self.ensure_rdd(data)
 
 
-class QueueStream(object):
+class QueueStream:
     def __init__(self, queue, oneAtATime=True, default=None):
         self.queue = queue
         self.oneAtATime = oneAtATime

--- a/pysparkling/streaming/tcpstream.py
+++ b/pysparkling/streaming/tcpstream.py
@@ -12,7 +12,7 @@ from ..rdd import EmptyRDD
 log = logging.getLogger(__name__)
 
 
-class TCPDeserializer(object):
+class TCPDeserializer:
     def __init__(self, context):
         self.context = context
 

--- a/pysparkling/task_context.py
+++ b/pysparkling/task_context.py
@@ -3,7 +3,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class TaskContext(object):
+class TaskContext:
     def __init__(self, cache_manager, catch_exceptions,
                  stage_id=0, partition_id=0, max_retries=3, retry_wait=0):
         self.cache_manager = cache_manager

--- a/pysparkling/tests/test_cache.py
+++ b/pysparkling/tests/test_cache.py
@@ -6,7 +6,7 @@ import time
 import pysparkling
 
 
-class Manip(object):
+class Manip:
     def __init__(self):
         self.count = 0
 

--- a/pysparkling/tests/test_context.py
+++ b/pysparkling/tests/test_context.py
@@ -52,7 +52,7 @@ class Context(unittest.TestCase):
 
     def test_retry(self):
 
-        class EverySecondCallFails(object):
+        class EverySecondCallFails:
             def __init__(self):
                 self.attempt = 0
 

--- a/pysparkling/tests/test_context.py
+++ b/pysparkling/tests/test_context.py
@@ -74,7 +74,7 @@ class Context(unittest.TestCase):
         self.assertEqual(union, ['Hello', 'World'])
 
     def test_version(self):
-        self.assertTrue(isinstance(pysparkling.Context().version, str))
+        self.assertIsInstance(pysparkling.Context().version, str)
 
 
 if __name__ == '__main__':

--- a/pysparkling/tests/test_multiprocessing.py
+++ b/pysparkling/tests/test_multiprocessing.py
@@ -137,7 +137,9 @@ class ProcessPool(unittest.TestCase):  # cannot work here: LazyTestInjection):
 
         start = time.time()
         r.collect()
-        self.assertLess(time.time() - start, 0.5)
+
+        # Yep... On Windows it's a lot slower!
+        self.assertLess(time.time() - start, 0.5 if platform.system() != 'Windows' else 1.1)
 
 
 class ProcessPoolIdlePerformance(unittest.TestCase):

--- a/pysparkling/tests/test_multiprocessing.py
+++ b/pysparkling/tests/test_multiprocessing.py
@@ -142,8 +142,7 @@ class ProcessPool(unittest.TestCase):  # cannot work here: LazyTestInjection):
         start = time.time()
         r.collect()
 
-        # Yep... On Windows it's a lot slower!
-        self.assertLess(time.time() - start, 0.5 if platform.system() != 'Windows' else 1.1)
+        self.assertLess(time.time() - start, 0.5)
 
 
 class ProcessPoolIdlePerformance(unittest.TestCase):

--- a/pysparkling/tests/test_multiprocessing.py
+++ b/pysparkling/tests/test_multiprocessing.py
@@ -18,7 +18,7 @@ import cloudpickle
 import pysparkling
 
 
-class Processor(object):
+class Processor:
     """This modifies lines but also keeps track whether it was executed."""
     def __init__(self):
         self.executed = False
@@ -28,7 +28,7 @@ class Processor(object):
         return '--- {}'.format(line)
 
 
-class LazyTestInjection(object):
+class LazyTestInjection:
     def lazy_execution_test(self):
         r = self.sc.textFile(__file__)  # pylint: disable=no-member
 

--- a/pysparkling/tests/test_rdd.py
+++ b/pysparkling/tests/test_rdd.py
@@ -163,7 +163,7 @@ class RDDTest(unittest.TestCase):
 
     def test_groupByKey(self):
         # This will fail if the values of the RDD need to be compared
-        class IncomparableValue(object):
+        class IncomparableValue:
             def __init__(self, value):
                 self.value = value
 
@@ -193,7 +193,7 @@ class RDDTest(unittest.TestCase):
 
     def test_reduceByKey(self):
         # This will fail if the values of the RDD need to be compared
-        class IncomparableValueAddable(object):
+        class IncomparableValueAddable:
             def __init__(self, value):
                 self.value = value
 
@@ -224,7 +224,7 @@ class RDDTest(unittest.TestCase):
 
     def test_reduceByKey_with_numPartition(self):
         # This will fail if the values of the RDD need to be compared
-        class IncomparableValueAddable(object):
+        class IncomparableValueAddable:
             def __init__(self, value):
                 self.value = value
 

--- a/pysparkling/tests/test_resolve_filenames.py
+++ b/pysparkling/tests/test_resolve_filenames.py
@@ -9,7 +9,7 @@ from pysparkling.fileio import File
 CURRENT_FILE_LOCATION = __file__
 
 
-class MockedHdfsClient(object):
+class MockedHdfsClient:
     def list(self, path, status):
         if path == "/user/username/":
             return [
@@ -25,7 +25,7 @@ class MockedHdfsClient(object):
         raise NotImplementedError("Return value not mocked for '{0}'".format(path))
 
 
-class MockedS3Bucket(object):
+class MockedS3Bucket:
     def list(self, *args, **kwargs):
         return [
             MockedS3Key("user/username/input/part-00001.gz"),
@@ -34,12 +34,12 @@ class MockedS3Bucket(object):
         ]
 
 
-class MockedS3Connection(object):
+class MockedS3Connection:
     def get_bucket(self, *args, **kwargs):
         return MockedS3Bucket()
 
 
-class MockedS3Key(object):
+class MockedS3Key:
     def __init__(self, name):
         self.name = name
 

--- a/pysparkling/utils.py
+++ b/pysparkling/utils.py
@@ -12,13 +12,13 @@ from typing import List, Optional, Union
 import pytz
 from pytz import UnknownTimeZoneError
 
-from pysparkling.sql.casts import get_time_formatter
-from pysparkling.sql.internal_utils.joins import (
+from .sql.casts import get_time_formatter
+from .sql.internal_utils.joins import (
     CROSS_JOIN, FULL_JOIN, INNER_JOIN, LEFT_ANTI_JOIN, LEFT_JOIN, LEFT_SEMI_JOIN, RIGHT_JOIN
 )
-from pysparkling.sql.schema_utils import get_on_fields
-from pysparkling.sql.types import create_row, Row, row_from_keyed_values
-from pysparkling.sql.utils import IllegalArgumentException
+from .sql.schema_utils import get_on_fields
+from .sql.types import create_row, Row, row_from_keyed_values
+from .sql.utils import IllegalArgumentException
 
 
 class Tokenizer:

--- a/pysparkling/utils.py
+++ b/pysparkling/utils.py
@@ -20,7 +20,7 @@ from pysparkling.sql.types import create_row, Row, row_from_keyed_values
 from pysparkling.sql.utils import IllegalArgumentException
 
 
-class Tokenizer(object):
+class Tokenizer:
     def __init__(self, expression):
         self.expression = expression
 
@@ -239,7 +239,7 @@ def format_cell(value):
     return str(value)
 
 
-class MonotonicallyIncreasingIDGenerator(object):
+class MonotonicallyIncreasingIDGenerator:
     def __init__(self, partition_index):
         self.value = partition_index * 8589934592 - 1
 
@@ -250,7 +250,7 @@ class MonotonicallyIncreasingIDGenerator(object):
 
 # pylint: disable=W0511
 # todo: store random-related utils in a separated module
-class XORShiftRandom(object):
+class XORShiftRandom:
     # pylint: disable=W0511
     # todo: align generated values with the ones in Spark
     def __init__(self, init):
@@ -297,7 +297,7 @@ class XORShiftRandom(object):
         return (highBits << 32) | (lowBits & 0xFFFFFFFF)
 
 
-class MurmurHash3(object):
+class MurmurHash3:
     @staticmethod
     def bytesHash(data, seed=0x3c074a61):
         length = len(data)

--- a/pysparkling/utils.py
+++ b/pysparkling/utils.py
@@ -7,6 +7,7 @@ from operator import itemgetter
 import random
 import re
 import sys
+from typing import List, Optional, Union
 
 import pytz
 from pytz import UnknownTimeZoneError
@@ -21,10 +22,10 @@ from pysparkling.sql.utils import IllegalArgumentException
 
 
 class Tokenizer:
-    def __init__(self, expression):
+    def __init__(self, expression: str):
         self.expression = expression
 
-    def next(self, separator=None):
+    def get_next(self, separator: Optional[Union[List[str], str]] = None) -> str:
         if isinstance(separator, list):
             separator_positions_and_lengths = [
                 (self.expression.find(s), s)
@@ -51,8 +52,8 @@ class Tokenizer:
 
 def parse_file_uri(expr):
     t = Tokenizer(expr)
-    scheme = t.next('://')
-    domain = t.next('/')
+    scheme = t.get_next('://')
+    domain = t.get_next('/')
     last_slash_position = t.expression.rfind('/')
     folder_path = '/' + t.expression[:last_slash_position + 1]
     file_pattern = t.expression[last_slash_position + 1:]

--- a/pysparkling/utils.py
+++ b/pysparkling/utils.py
@@ -244,7 +244,10 @@ class MonotonicallyIncreasingIDGenerator:
     def __init__(self, partition_index):
         self.value = partition_index * 8589934592 - 1
 
-    def next(self):
+    def __iter__(self):
+        return self
+
+    def __next__(self):
         self.value += 1
         return self.value
 

--- a/scripts/pyspark_comparisons.py
+++ b/scripts/pyspark_comparisons.py
@@ -9,9 +9,9 @@ def simple_textFile():
     print(SC.parallelize([1, 2, 3]).name())
 
 
-def indent_line(lst):
+def indent_line(l):
     print('============== INDENTING LINE ================')
-    return '--- ' + lst
+    return '--- ' + l
 
 
 def lazy_execution():

--- a/scripts/pyspark_comparisons.py
+++ b/scripts/pyspark_comparisons.py
@@ -9,9 +9,9 @@ def simple_textFile():
     print(SC.parallelize([1, 2, 3]).name())
 
 
-def indent_line(l):
+def indent_line(lst):
     print('============== INDENTING LINE ================')
-    return '--- ' + l
+    return '--- ' + lst
 
 
 def lazy_execution():

--- a/scripts/readme_example_human_microbiome.py
+++ b/scripts/readme_example_human_microbiome.py
@@ -3,4 +3,4 @@ from pysparkling import Context
 by_subject_rdd = Context().textFile(
     's3n://human-microbiome-project/DEMO/HM16STR/46333/by_subject/*'
 )
-print(by_subject_rdd.takeSample(1))
+print(by_subject_rdd.takeSample(True, 1))

--- a/scripts/tcpperf_client.py
+++ b/scripts/tcpperf_client.py
@@ -16,7 +16,7 @@ from tornado.iostream import StreamClosedError
 from tornado.tcpclient import TCPClient
 
 
-class Emitter(object):
+class Emitter:
     def __init__(self, port, n=1000, values=1, duration=3.0):
         self.port = port
         self.n = n

--- a/scripts/tcpperf_plot.py
+++ b/scripts/tcpperf_plot.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 matplotlib.use('Agg')
 
 
-class Plot(object):
+class Plot:
     def __init__(self, filename, x_label=None, y_label=None):
         self.filename = filename
         self.x_label = x_label or 'connections per second'

--- a/scripts/tcpperf_server.py
+++ b/scripts/tcpperf_server.py
@@ -15,7 +15,7 @@ N_CONNECTIONS = (100, 1000, 2000, 3000, 3500, 4000, 4500, 5000,
 N_CONNECTIONS_1K = (10, 20, 30, 40, 45, 50, 60, 70, 80, 90, 100)
 
 
-class Server(object):
+class Server:
     def __init__(self, pause=60, values=1, start_port=8123, processes=2):
         self.pause = pause
         self.values = values

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = H301
+ignore = W503, E731
 exclude = venv*,logo,docs,build
 max-line-length = 119
 


### PR DESCRIPTION
- Cleanup the pylint things that were ignored. Most notably the cyclic-imports.
- Made all internal references relative. Don't import pysparkling itself anymore from within the library.
- Removed (object) inheritance. It's the only way anyway on Python3.
- `Tokenizer::next` failed on pylint. Likely because pylint confuses it with the internal `next` command? Renamed it to get_next to silence the error... I don't like it, but I prefer to have the switch enabled to capture other use cases.
